### PR TITLE
SS14.Admin Setup: Make it more apparent to enter client id instead of client app name

### DIFF
--- a/src/en/server-hosting/setting-up-ss14-admin.md
+++ b/src/en/server-hosting/setting-up-ss14-admin.md
@@ -68,7 +68,7 @@ ForwardProxies:
 # Your way of authenticating accounts, the docs will set it up with an ss14 account 
 Auth:
     Authority: "https://central.spacestation14.io/web/"
-    ClientId: "ss14-admin"
+    ClientId: "9e2ce26f-EDIT-THIS-b4d9-8cc08993b33e"
     ClientSecret: "foobar"
 
 authServer: "https://central.spacestation14.io/auth"


### PR DESCRIPTION
This change was reflected a while ago after the new docs had the old version. But this one looks a lil better then the current docs