### PR TITLE
Off-station ghost roles [Doru991]

### DIFF
--- a/src/en/proposals/doru991-off-station-ghost-roles.md
+++ b/src/en/proposals/doru991-off-station-ghost-roles.md
@@ -1,0 +1,29 @@
+# Off-station ghost roles [Doru991]
+Off-station ghost roles are ghost roles that operate in an area completely independent from the main station and its inhabitants. They will interact/cooperate with each other by nature, but they will rarely if ever come in contact with the main station's crew, much less affect the outcome of the ongoing round in any significant manner.
+
+# The 'Why'
+Dying permanently is not a rare occurence in SS14. Whether due to one's own incompetence, a syndicate agent's objectives (or their fun at the expense of others') or the zombie apocalypse, at least several players will, over the course of a round, find themselves unable to return to their original body after death.
+This usually gives you two options: Spectate and ~~mald~~ talk in deadchat, where even fellow ghosts will often ignore you, or take one of many ghost roles available.
+There's usually many ghost roles available, but the issue is that, save for the exceedingly rare mid-round antags, almost none of them are fun and engaging to play, or have any real *agency* of their own.
+
+# The solution
+Off-station ghost roles deal with the possibility of metagaming and metagrudging by being completely removed from the round at large, making any knowledge about who killed them, who is a syndie etc. practically useless. This allows for much more engaging gameplay while not risking a possible compromise of the round's integrity.
+
+Ideally, off-station ghost roles would take place on a different map than the one the station is placed on, in order to prevent them from interacting with each other via various shenanigans.
+
+# Proposed role: Derelict with cryostasis pods
+This would basically be a remake of SS13's Charlie Station ghost roles.
+Players would find themselves awakening from stasis in an abandoned, depowered and rundown station. Gameplay would be drastically different from what you'd expect on a still-maintained station, some examples being:
+* There would definitely be no AME, so they would have to use PACMAN and similar generators to jumpstart the station's power infrastructure, later on setting up alternative means of power such as solars or even the singulo.
+* Food and drink would be scarce compared to a regular station, so players will have to set up hydroponics and retrieve water tanks in order to have reliable sustenance.
+* Medicine would also be harder to come by, mostly found in the destroyed medbay or rarely in medkits from maints and such.
+* In order to help with gathering/renewing materials, the station would have some small asteroids embedded into it, and survivors could maybe salvage a salvage magnet (ironic) from the cargo bay.
+* While the spawn area would be relatively safe, as players delved deeper into the derelict they'd come face to face with hazards such as spaced rooms and increasingly strong hostile mobs.
+* Proper gear would also be harder to come by, encouraging the use of makeshift alternatives. However, some relatively powerful stuff could be guarded by powerful mobs and traps such as xeno turrets.
+
+## Objectives
+The main objective is obviously survival, but otherwise gameplay would be open ended, so players could choose to either make the old, rusty station into a proper home, wipe out all the aliens who overtook the station, or attempt to assemble a shoddy shuttle with whatever they have on hand and escape to Centcom once the round draws to a close.
+
+## Difficulty
+The abandoned station should obviously be a rather harsh environment.
+I think it should, in principle, be 'beatable' solo, but it would be very punishing and difficult as one single mistake could end your 'run'. Therefore, waiting for more survivors to awaken and braving the station you used to call home together would be a much more viable strategy, as you could do more tasks at once and help get anyone who falls to one of the many threats back on their feet.


### PR DESCRIPTION
Yay first new design doc PR'd via github
Uh I don't think there's a template for these yet so
Yeah so basically this adds the design doc about off-station ghost roles that I posted on Discord earlier. I think it's a good/useful feature because perma-dying isn't exactly rare and the ghost roles we currently have are a bit lackluster, which is understandable because we don't want them to affect the flow of the round very much.
So simply creating a subset of ghost roles that isn't on the station and doesn't affect it should allow for more agency and fun gameplay overall.
This isn't totally finished/fleshed out so it'll be a draft for now, waiting for everyone's feedback.