### PR TITLE
SS14.Watchdog setup: Remove partial clone sugestion

### DIFF
--- a/src/en/server-hosting/setting-up-ss14-watchdog.md
+++ b/src/en/server-hosting/setting-up-ss14-watchdog.md
@@ -31,8 +31,8 @@ Both of these can be found at the [.NET 6 download page](https://dotnet.microsof
 
 The following set of commands should build the Watchdog on a Linux system. You'll have to adjust it according to your actual system, of course.
 ```
-# Download the SS14.Watchdog repository and any submodules/etc (but not their history).
-git clone --recursive --depth=1 https://github.com/space-wizards/SS14.Watchdog
+# Download the SS14.Watchdog repository and any submodules/etc.
+git clone --recursive https://github.com/space-wizards/SS14.Watchdog
 
 # Switch into the SS14.Watchdog directory.
 cd SS14.Watchdog


### PR DESCRIPTION
Bad practice in general especially since rn its broken and with this you cant checkout to the previous commit without recloning first

Also its like... 5mb max? with history?

It has no submodules too but i guess we can keep `recursive` for the future.