### PR TITLE
Fix the Design Proposals splitter in SUMMARY.md

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -117,12 +117,12 @@ Space Station 14
 
 Design Proposals
 ================
-- [Anomaly cores](en/proposals/anomaly-cores.md)
-- [PDA messaging](en/proposals/pda-messaging.md)
-- [Plant genetics](en/proposals/deltanedas-plant-genetics.md)
 
 ----------------------
 
+- [Anomaly cores](en/proposals/anomaly-cores.md)
+- [PDA messaging](en/proposals/pda-messaging.md)
+- [Plant genetics](en/proposals/deltanedas-plant-genetics.md)
 - [Security Genpop Rework](en/proposals/genpop_security.md)
 
 Server Hosting


### PR DESCRIPTION
The splitter goes below the subsection header for every other subsection you goobers:

![image](https://github.com/space-wizards/docs/assets/5714543/d46726f9-73e2-4cdf-9db8-15228fd70da6)

These other design proposals were added after Genpop was opened but before it was merged.