### PR TITLE
Fix small typo in ecs.md

### DIFF
--- a/src/en/robust-toolbox/ecs.md
+++ b/src/en/robust-toolbox/ecs.md
@@ -96,7 +96,7 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    subgraph Cofee Maker Machine
+    subgraph Coffee Maker Machine
     Damageable;
     PowerReceiver;
     SolutionContainer;


### PR DESCRIPTION
one of the charts said "cofee maker machine", changed "cofee" to "coffee".