### PR TITLE
Add new entry to admin cookbook and change title

### DIFF
--- a/src/en/community/admin/admin-tooling/admin-command-cookbook.md
+++ b/src/en/community/admin/admin-tooling/admin-command-cookbook.md
@@ -1,10 +1,12 @@
-# Admin Command Cookbook
+# Admin Cookbook
 
 ## Delete PA & Singularity Generator
 ```
     entities named "PA .*" do delete $ID
     deleteewi SingularityGenerator
 ```
+## Add power to the station permanently
+`Admin menu -> objects -> select grids in dropdown -> right click the station -> tricks -> click the battery with the ∞`
 ## Uncurse all lockers
 `entities with CursedEntityStorage do rmcomp $ID CursedEntityStorage; addcomp $ID EntityStorage`
 ## Remove all ghostroles


### PR DESCRIPTION
Restoring power to the station is a useful and cook-book-y action. It's definitely something that should be documented in the wiki somewhere. Even though it isn't a command, no other place seems better for it than the admin command cookbook. This commit changes the cookbook's title to encompass admin cook-book-y things in general, and it adds the new entry to it.