### PR TITLE
Neutral Antag proposal: Pizza Delivery Critter

### DIFF
--- a/src/en/proposals/fairlysadpanda-pizzadelivery.md
+++ b/src/en/proposals/fairlysadpanda-pizzadelivery.md
@@ -1,0 +1,80 @@
+# Arnold's Pizza Delivery Service
+
+| Designers      | Implemented | GitHub Links |
+| -------------- | ----------- | ------------ |
+| FairlySadPanda | :x: No      | TBD          |
+
+# Arnold's Pizza Needs Delivery Critters
+
+- Alone?
+- Gullible?
+- Poor?
+- Unaware of our reputation?
+
+If most/all of these apply to you, _or_ we've successfully kidnapped you from your home, then Arnolds Pizza has a job with your name on it!
+
+We need delivery critters willing to do one of the most difficult and thankless tasks in known space: delivering pizzas to NanoTrasen employees!
+
+NanoTrasen knows we make the best pizza in the galaxy*. That's why they have an exclusive contract with us to fulfil their Random Reward Pizza employee satisfaciton scheme. However, NanoTrasen's boutique, black-ops and (frequently) badly-maintained space stations are both challenging to access and deliver to. The fell-off-a-back-of-a-van BlueSpace teleporation devices that we use for such challenging customers are both extremely unethical *and\* have a carry-limit small enough that we can't send a full-sized sapient creature through with our KeepWarm pizza boxes in tow!
+
+That means there's a _unique_ and _exciting_ opportunity for small, light, _expendable_ critters in our delivery services. Join today, and we promise that we'll let you leave afterward. Just remember to get that receipt!
+
+\*As do the Syndicate, but we don't tell them that.
+
+# Overview
+
+Building on positive player feedback from the April Fools Legally Distinct Space Ferret neutral antagonist, this design document outlines a role that sees the player play as a small, agile critter on a time-limited mission to complete a delivery task to a member of the crew. Success is delivery and retreival of a signed receipt: failure is a tragic death due to the compromising of the nuclear fission heater that the delivery company has strapped to said critter's back.
+
+## Player Profiles
+
+- **Pop-In** wants to pop-in to to the round for a few minutes and interact with the crew, but doesn't have time to stick around for the evac shuttle.
+- **Cutesy Gamer** wants to play as a cute critter with more than just roleplaying to do.
+- **Comedy Gamer** wants to be placed in a tense, absurd situation where their game knowledge can shine to get a challenging goal done.
+
+## How it works
+
+- A mid-round ghost role of "Pizza Delivery critter" allows a player to spawn as a cute sapient critter similar to a monkey or kobold at appropriate spawns decided by the map creator, or by mimicing vent critter spawning should this retrofitting have not taken place.
+- This critter is given two sets of information:
+  1. The identity of its delivery target, including their face, profession and name.
+  2. The amount of time they have to complete the delivery before the KeepWarm heater on their back violently explodes.
+- The timer is constantly displayed at the bottom of the screen, above the equipment bar. This is a reference, appropriately enough, to _Pizza Tower_.
+- The critter is a neutral antagonist with one objective:
+  - Get a signed reciept from the target before time runs out.
+- The critter's target must be alive and not in crit to be chosen.
+  - If the target is gibbed or becomes SSD for any reason during the delivery attempt, Arnold's Pizza declares the order void and the player is freed from the timer. If this happens, they get to eat the pizza. This is the "neutral" end condition for this antag - the player will not greentext, but they do not get round-removed.
+- The critter the player plays at has the following abilities:
+  - Small creature hitboxes, allowing it to slide underneath most doors. Arnold's Pizza has extensive experience dealing with NT stations and has engineered its delivery critters to be able to actually have a chance of delivering to Urist McScientist who is sitting behind three secure airlocks.
+  - The following item slots:
+    - Hat
+    - Mask
+    - Belt
+    - Pocket (with a pen)
+    - PDA/ID Card
+    - One hand slot
+  - The critter spawns with no items other than a cute hat.
+  - The critter is not especially vulnerable to any damage type, breathes oxygen, but has no capacity at all to wear a spacesuit. Their mask, belt and pocket slots allow them to get O2
+    in the event the station is spaced, but they will die to barotrauma somewhat quickly.
+  - The critter has the same amount of health as a monkey.
+  - The critter nyooms - that is, they have a higher-than-average base and running speed, appropriate for a frantic delivery vehicle.
+  - The critter only speaks in cute noises unless given cognizine.
+- The critter has the ability to print out a receipt for its order. This receipt contains the same information the critter was given regarding the target's identity.
+- The receipt has a space for a signature. The only way this signature can be filled in is by the target. It needs to be filled in by using a pen (of any kind) on the receipt.
+- The receipt must be handed back to the critter, who then must feed it back into the heater to retrieve the pizza. This counts as a victory and allows the critter to greentext.
+- The pizza is one of Arnold's specials. The pizza will have one of the following properties:
+  - Dank: contains, as you'd expect, dankness, and gives the user hallucinations (cannabis).
+  - Healthy: like the current Arnold's pizza item, this contains a powerful healing agent (omnizine).
+  - Stimulants: this pizza is loaded with sugar and makes the target nyoom for a medium period.
+  - Hot N Spicy: eating the pizza causes the target to set on fire.
+  - Space Carp Pizza allows the target to avoid pressure damage for a medium period.
+  - Classic: (PRE WOUND MED) causes the target to detonate. (POST WOUND MED) causes the target's limbs to fly off.
+  - All of these pizzas have a "paper-oni" pizza variant for moths to eat.
+- The pizza types have clear labels on their boxes and unique descriptions, but do not overtly say what they do. The positive-effect pizzas are weighted more likely to appear than the negative ones, with the Classic pizza being a rare chance.
+- If the critter fails to deliver the pizza in the time limit, it explodes. This explosion is faked - it gibs the critter but convers no damage to anyone else standing nearby, even on the same tile, to prevent this feature being abused to suicide bomb people.
+- It is possible for a member of the crew with bomb disposal knowledge to disable the KeepWarm heater, thus saving the critter's life. If this occurs, the critter cannot greentext.
+
+## Traitor/Nukeops Gameplay
+
+- The Syndicate also have an exclusive contract with Arnold's Pizza, and they leverage that to do a little trolling and help themselves out.
+- A traitor or nukie can order a pizza delivery for themselves or a member of NanoTrasen crew. If they do this, they can specify what exactly the critter is going to deliver. This includes a new, exciting flavour: a bomb with a fuse that looks like it fell out of a Looney Tunes cartoon. The bomb is much too heavy for the critter to hold, and they drop it immediately.
+- This bomb detonates a few seconds after the critter has retrieved it from its KeepWarm heater, doing moderate damage to the station in the process.
+  - This is a reference both to Looney Tunes and the famous "sometimes you just can't get rid of a bomb" sketch from the Adam West Batman TV series.

--- a/src/en/proposals/fairlysadpanda-pizzadelivery.md
+++ b/src/en/proposals/fairlysadpanda-pizzadelivery.md
@@ -45,14 +45,13 @@ Building on positive player feedback from the April Fools Legally Distinct Space
 - The critter the player plays at has the following abilities:
   - Small creature hitboxes, allowing it to slide underneath most doors. Arnold's Pizza has extensive experience dealing with NT stations and has engineered its delivery critters to be able to actually have a chance of delivering to Urist McScientist who is sitting behind three secure airlocks.
   - The following item slots:
-    - Hat
+    - Hat (containing a branded red Arnold's Pizza cap that itself contains a tiny item storage slot, containing a pen)
     - Mask
-    - Belt
-    - Pocket (with a pen)
+    - Belt (containing a branded o2 canister)
+    - Pocket (with a branded gas mask)
     - PDA/ID Card
     - One hand slot
-  - The critter spawns with no items other than a cute hat.
-  - The critter is not especially vulnerable to any damage type, breathes oxygen, but has no capacity at all to wear a spacesuit. Their mask, belt and pocket slots allow them to get O2
+  - The critter is not especially vulnerable to any damage type, breathes oxygen, but has no capacity at all to wear a spacesuit. They are provided with the means to survive atmos failure, though, preventing frustrating spawns.
     in the event the station is spaced, but they will die to barotrauma somewhat quickly.
   - The critter has the same amount of health as a monkey.
   - The critter nyooms - that is, they have a higher-than-average base and running speed, appropriate for a frantic delivery vehicle.
@@ -71,6 +70,9 @@ Building on positive player feedback from the April Fools Legally Distinct Space
 - The pizza types have clear labels on their boxes and unique descriptions, but do not overtly say what they do. The positive-effect pizzas are weighted more likely to appear than the negative ones, with the Classic pizza being a rare chance.
 - If the critter fails to deliver the pizza in the time limit, it explodes. This explosion is faked - it gibs the critter but convers no damage to anyone else standing nearby, even on the same tile, to prevent this feature being abused to suicide bomb people.
 - It is possible for a member of the crew with bomb disposal knowledge to disable the KeepWarm heater, thus saving the critter's life. If this occurs, the critter cannot greentext.
+- If the target is in crit or cuffed, using the printed receipt on them whilst the critter has a pen in their pocket allows the critter to forge the signature, greentexting.
+- If the critter has delivered its pizza, it can become eligible to deliver another pizza again later in the round provided the pizza delivery event is rolled again (or if an admin is feeling cruel).
+- The critter always has the option of aborting the mission and teleporting back off the station, to avoid feel-bad moments where the objective is undeliverable, the station is in too bad a state to attempt a delivery, etc.
 
 ## Traitor/Nukeops Gameplay
 
@@ -78,3 +80,5 @@ Building on positive player feedback from the April Fools Legally Distinct Space
 - A traitor or nukie can order a pizza delivery for themselves or a member of NanoTrasen crew. If they do this, they can specify what exactly the critter is going to deliver. This includes a new, exciting flavour: a bomb with a fuse that looks like it fell out of a Looney Tunes cartoon. The bomb is much too heavy for the critter to hold, and they drop it immediately.
 - This bomb detonates a few seconds after the critter has retrieved it from its KeepWarm heater, doing moderate damage to the station in the process.
   - This is a reference both to Looney Tunes and the famous "sometimes you just can't get rid of a bomb" sketch from the Adam West Batman TV series.
+- The critter is not told they are delivering a bomb or that they're working for the Syndicate, and there's no metagameable way to know if a pizza delivery is legitimate or a trap.
+- This mechanic makes sure that there's a theoretical reason that a player may refuse a delivery.


### PR DESCRIPTION
# Arnold's Pizza Needs You!

![image](https://github.com/space-wizards/docs/assets/732532/51cb9f9e-9e9c-41fe-abff-79edd8042e6e)

- Alone?
- Gullible?
- Poor?
- Unaware of our reputation?

If most/all of these apply to you, _or_ we've successfully kidnapped you from your home, then Arnolds Pizza has a job with your name on it!

We need delivery critters willing to do one of the most difficult and thankless tasks in known space: delivering pizzas to NanoTrasen employees!

NanoTrasen knows we make the best pizza in the galaxy*. That's why they have an exclusive contract with us to fulfil their Random Reward Pizza employee satisfaciton scheme. However, NanoTrasen's boutique, black-ops and (frequently) badly-maintained space stations are both challenging to access and deliver to. The fell-off-a-back-of-a-van BlueSpace teleporation devices that we use for such challenging customers are both extremely unethical *and\* have a carry-limit small enough that we can't send a full-sized sapient creature through with our KeepWarm pizza boxes in tow!

That means there's a _unique_ and _exciting_ opportunity for small, light, _expendable_ critters in our delivery services. Join today, and we promise that we'll let you leave afterward. Just remember to get that receipt!

*As do the Syndicate, but we don't tell them that.

---

Note that this PR makes no suggestion for what the delivery critters should look like. The illustrative art above is just where my brainrot took me when designing this feature.