### PR TITLE
fix: Updated the path for template proposals

### DIFF
--- a/src/en/general-development/feature-proposals.md
+++ b/src/en/general-development/feature-proposals.md
@@ -4,7 +4,7 @@ If you are considering adding or reworking some major component of the game it's
 
 ## How do I make a proposal?
 
-1. Make a copy of the design proposal template located at `src/en/proposals/proposal-template.md`.
+1. Make a copy of the design proposal template located at `src/en/templates/proposal.md`.
    
 3. Read through [SS14's Core Design Documentation](../space-station-14/core-design.md) (for gameplay-related proposals).
 


### PR DESCRIPTION
Fixes the path on 
https://docs.spacestation14.com/en/general-development/feature-proposals.html

![image](https://github.com/space-wizards/docs/assets/103440971/2456cb48-3da8-4235-8ad2-376f34129ae8)

https://github.com/space-wizards/docs/commit/f1fcbeecfd108ed16a1b5154db54e9cea5d5aeff
https://github.com/space-wizards/docs/commit/4d870eca71b963174199eda622b90aedb14332df
https://github.com/space-wizards/docs/commit/e12e6cdf9d8743de8b83fdd1a984ca40183ca1d4