### PR TITLE
Port maintainer list from mdbook to the wiki

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -191,6 +191,7 @@ Community
   - [Grafana Dashboards](en/community/infrastructure-reference/grafana-dashboards.md)
 - [Space Wizards Hub Rules](en/community/space-wizards-hub-rules.md)
 - [Space Wizards Role Hierarchy](en/community/space-wizards-role-hierarchy.md)
+- [Space Wizards Maintainer List](en/community/space-wizards-maintainer-list.md)
 - [Discord Rich Presence Repository](en/community/discord-rich-presence-repository.md)
 - [Admin](en/community/admin.md)
   - [Admin Tooling](en/community/admin/admin-tooling.md)

--- a/src/en/community/space-wizards-maintainer-list.md
+++ b/src/en/community/space-wizards-maintainer-list.md
@@ -1,0 +1,43 @@
+# Space Wizard Maintainer List
+This document shows all current Maintainer on the project. Along with their github and discord contact.
+
+I will do my best to keep this up to date as maints come and leave.
+
+The format is as follows
+
+**Github - Discord (ID)**
+
+Both engine and content Maintainers:
+- [Jezithyr](https://github.com/Jezithyr) - @jezithyr (107689319396831232)
+- [ZoldorfTheWizard](https://github.com/ZoldorfTheWizard) - @zoldorf (140921734109855744)
+- [PJB3005](https://github.com/PJB3005) - @pjb (97089048065097728)
+- [ShadowCommander](https://github.com/ShadowCommander) - @shadowcommander (104693014407950336)
+- [DrSmugleaf](https://github.com/DrSmugleaf) - @drsmugleaf (109067752286715904)
+- [mirrorcult](https://github.com/mirrorcult) - @mirrorcult (176065747200507904)
+- [metalgearsloth](https://github.com/metalgearsloth) - @metalgearsloth (229052932476108800)
+- [Visne](https://github.com/Visne) - @visne (182723474257608705)
+- [keronshb](https://github.com/keronshb) - @keronshb (226429200553213952)
+- [AJCM-git](https://github.com/AJCM-git) - @ajcm_git (239467362380808192)
+- [ElectroJr](https://github.com/ElectroJr) - @electrosr (348118974497816577)
+- [vulppine](https://github.com/vulppine) - @vulppine (102244617314914304)
+
+Content maitainers:
+- [Partmedia](https://github.com/Partmedia) - @notafet (774744999379599360)
+- [Emisse](https://github.com/Emisse) - @emisse (109430489684705280)
+- [Chief-Engineer](https://github.com/Chief-Engineer) - @am.ghost (267392122179682307)
+
+Junior Maintainers:
+- [Tayrtahn](https://github.com/Tayrtahn) - @tayrtahn (147050540214386689)
+- [deathride58](https://github.com/deathride58) - @bhijn (77867936647225344)
+- [VasilisThePikachu](https://github.com/VasilisThePikachu) - @vasilisiscool (322708417540259841)
+- [Slava0135](https://github.com/Slava0135) - @slava0135 (439814569972727818)
+- [ficcialfaint](https://github.com/ficcialfaint) - @ficcialfaint (481532274211422209)
+- [chromiumboy](https://github.com/chromiumboy) - @chromiumboy (395222876753625088)
+- [TemporalOroboros](https://github.com/TemporalOroboros) - @the_quiet_one (423542163503185942)
+- [Flareguy](https://github.com/Flareguy) - @flar3guy (310216766192091156)
+- [TheShuEd](https://github.com/TheShuEd) - @eshhhed (267327466060775425)
+- [EmoGarbage404](https://github.com/EmoGarbage404) - @emogarbage (500128901805244436)
+- [LankLTE](https://github.com/LankLTE) - @lanklte (328292818265047041)
+
+Engine maintainers:
+No one maintains only engine :p

--- a/src/en/community/space-wizards-maintainer-list.md
+++ b/src/en/community/space-wizards-maintainer-list.md
@@ -1,13 +1,13 @@
 # Space Wizard Maintainer List
-This document shows all current Maintainer on the project. Along with their github and discord contact.
+This document shows all current Maintainers on the project. Along with their GitHub and Discord contacts.
 
-I will do my best to keep this up to date as maints come and leave.
+I will do my best to keep this up to date as Maintainers come and leave.
 
 The format is as follows
 
 **Github - Discord (ID)**
 
-Both engine and content Maintainers:
+Both Engine and Content Maintainers:
 - [Jezithyr](https://github.com/Jezithyr) - @jezithyr (107689319396831232)
 - [ZoldorfTheWizard](https://github.com/ZoldorfTheWizard) - @zoldorf (140921734109855744)
 - [PJB3005](https://github.com/PJB3005) - @pjb (97089048065097728)
@@ -21,7 +21,7 @@ Both engine and content Maintainers:
 - [ElectroJr](https://github.com/ElectroJr) - @electrosr (348118974497816577)
 - [vulppine](https://github.com/vulppine) - @vulppine (102244617314914304)
 
-Content maitainers:
+Content Maintainers:
 - [Partmedia](https://github.com/Partmedia) - @notafet (774744999379599360)
 - [Emisse](https://github.com/Emisse) - @emisse (109430489684705280)
 - [Chief-Engineer](https://github.com/Chief-Engineer) - @am.ghost (267392122179682307)


### PR DESCRIPTION
https://hackmd.io/7mwrXfpHTWmXcS2tE1_uSA

Had made this when someone said they needed a list for seeing names from GitHub to discord and I thought it should probably be more reachable so here it is!

