### PR TITLE
Toolshed coding conventions

### DIFF
--- a/src/en/general-development/codebase-info/conventions.md
+++ b/src/en/general-development/codebase-info/conventions.md
@@ -420,6 +420,24 @@ For things such as DoAfter, always use events instead of async.
 Async for any game simulation code should be avoided at all costs, as it's generally virulent, cannot be serialized (in the case of DoAfter, for example), and usually causes icky code.
 Events, on the other hand, tie in nicely with the rest of the game's architecture, and although they aren't as convenient to code, they are definitely way more lightweight.
 
+## Toolshed
+
+### Code structuring
+Toolshed commands should always be defined under a `Toolshed` subdirectory and namespace.
+
+### Naming
+- Always suffix toolshed command classes with `Command`.
+Example: `PlayerCommand`, `StationCommand`
+NOT: `PlayerCommands`, `PlayerToolshed` ...
+
+- Toolshed commands that have subcommands should always be singular form.
+Example: `station:list`
+NOT: `stations:list`
+
+- Toolshed commands should be all lowercase without underscores.
+Example: `station:largestgrid`
+NOT: `station:largest_grid`, `station:largestGrid`
+
 ## UI
 
 ### XAML and C#-defined UIs


### PR DESCRIPTION
Adds coding conventions for toolshed. There are a few inconsistencies I've noticed, which this PR will standardize: 
- Some toolshed commands are defined in a `Commands` namespace/directory, some in a `Toolshed` namespace/directory, and some are just put directly under `Content.Server/Whatever`.
- Most command names use all lowercase, but some use camelCase (`stations:rerollBounties`) or snake_case (`physics:angular_velocity`).
- Some command groups use singular (`player:list`) and some use plural (`stations:list`).