### PR TITLE
Update maintainer-policy.md

### DIFF
--- a/src/en/staff/maintainer-policy.md
+++ b/src/en/staff/maintainer-policy.md
@@ -8,13 +8,13 @@ This does not apply to rule change PRs from the Head Game Admins.
 - **If in doubt, continue with the procedure and ping anyways.**
 
 You **MUST**:
-- Link the PR in [#maint-review-pings](https://discord.com/channels/310555209753690112/1258585578618884167) AND ping @Review Pings and any relevant Design Work Groups for review.
+- Link the PR in [#maint-review-pings](https://discord.com/channels/310555209753690112/1258585578618884167) AND ping any relevant Design Work Groups for review.
 If this PR may affect game admins too (rules, rule clarifications, round flow, etc) **all Head Game Admins must be pinged as well.**
   - **If you are not sure, ping Head Game Admins anyways.**
   - It is up to anyone organizing work groups to create a new one if relevant.
     - **If a new work group is created due to this, a further 24 hours are added to this process.**
-- The PR must have at least one **Maintainer** approving it, and at least 24 hours must have passed since you pinged @Review Pings, the relevant Design Groups, and Game Admins if applicable in that channel, with no one dissenting to merging said PR.
-- Once those 24 hours are up:
+- The PR must have at least one **Maintainer** approving it, and at least 3 days must have passed since you pinged the relevant Design Groups, and Game Admins if applicable in that channel, with no one dissenting to merging said PR.
+- Once the time is up:
   - If no one dissents, the PR can be merged.
   - If there is dissent, the PR author must be notified on GitHub of people's requests for changes and/or arguments against it. You do not need to put a ton of effort in summarizing people's points, simply list opinions as "Maintainer opinion" and "Game Admin opinion".
     - **These opinions must be communicated in a neutral manner, even if you disagree with them.**


### PR DESCRIPTION
Removes the ping role reference for the moment and changes 24 hours to 3 days so people get more time to check.