### PR TITLE
Add an additional toolshed guide with examples.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -27,7 +27,7 @@ General Development
   - [Codebase Organization](en/general-development/codebase-info/codebase-organization.md)
   - [Acronyms & Nomenclature](en/general-development/codebase-info/acronyms-and-nomenclature.md)
 - [Tips](en/general-development/tips.md)
-  - [Beginner FAQ](en/general-development/tips/beginner-faq.md) 
+  - [Beginner FAQ](en/general-development/tips/beginner-faq.md)
   - [Troubleshooting FAQ](en/general-development/tips/troubleshooting-faq.md)
   - [Debugging Tools](en/general-development/tips/debugging-tools.md)
   - [PRs With Engine Changes](en/general-development/tips/prs-with-engine-changes.md)
@@ -51,7 +51,7 @@ SS14 By Example
   - [Porting Appearance Visualizers](en/ss14-by-example/making-a-sprite-dynamic/porting-appearance-visualizers.md)
 - [Basic Networking and You](en/ss14-by-example/basic-networking-and-you.md)
 - [Fluent and Localization](en/ss14-by-example/fluent-and-localization.md)
-- [UI Survival Guide](en/ss14-by-example/ui-survival-guide.md) 
+- [UI Survival Guide](en/ss14-by-example/ui-survival-guide.md)
 
 
 Robust Toolbox
@@ -77,6 +77,7 @@ Robust Toolbox
     - [Entities](en/robust-toolbox/toolshed/commands/entity-control.md)
     - [General](en/robust-toolbox/toolshed/commands/general.md)
     - [Miscellaneous](en/robust-toolbox/toolshed/commands/misc.md)
+  - [Toolshed Examples](en/robust-toolbox/toolshed/toolshed-examples.md)
 - [User Interface](en/robust-toolbox/user-interface.md)
 - [IoC](en/robust-toolbox/ioc.md)
 - [Rendering]()
@@ -164,7 +165,7 @@ Space Station 14
 	- [Proposals]()
 	  - [PAI Expansion Slots](en/space-station-14/player-interaction/proposals/pai-expansion-slots.md)
 	  - [PDA Messaging](en/space-station-14/player-interaction/proposals/pda-messaging.md)
-	  - [Grid Inventory](en/space-station-14/player-interaction/proposals/grid-inventory.md) 
+	  - [Grid Inventory](en/space-station-14/player-interaction/proposals/grid-inventory.md)
 
 - [Roleplay/Lore](en/space-station-14/roleplay-lore.md)
 	- [PR Guidelines](en/space-station-14/roleplay-lore/guidelines.md)

--- a/src/en/robust-toolbox/toolshed.md
+++ b/src/en/robust-toolbox/toolshed.md
@@ -5,7 +5,7 @@
 Toolshed is one of the three primary built-in debug tools (alongside `scsi` and View Variables.) for RobustToolbox, functioning as the game's development console. To use Toolshed, open the debug console or use the debug console in `devwindow`.
 
 ```admonish warning
-Toolshed is not yet available on the client, so you need to use the `>` prefix command on the client in order to run its commands server-side.
+Toolshed is not yet available on the client, so you need to use the `>` prefix command on the client in order to run its commands server-side. Ommiting this will often result in an error stating that you lack permission to run the command even if this is not the case.
 ```
 
 Toolshed is a **pipeline shell**, and the primary method of performing complex actions is composition of commands. You can simply write multiple commands one after the other and as long as they are compatible, they will have their inputs successively fed to one another. For example, take the following **command run**:
@@ -14,7 +14,7 @@ Toolshed is a **pipeline shell**, and the primary method of performing complex a
 entities with Item count
 ```
 
-This is three commands, `entities`, `with`, and `count`. They together form a **command run**, a set of successive commands. You can use the `explain` command to provide information about a command run's flow. It's highly recommended you `explain` command runs you don't understand to get an idea of their flow.
+This is three commands, `entities`, `with`, and `count`. They together form a **command run**, a set of successive commands. You can use the `explain` command to provide information about a command run's flow. It's highly recommended you `explain` command runs you don't understand to get an idea of their flow. Note that unlike other pipeline based shells, toolshed's pipeing is *implicit*; you do not need to include a special pipe symbol for commands to be joined into a pipeline. Simply writing them one after another is enough.
 
 ```
 {{#include toolshed/explain_example_1.txt}}
@@ -32,3 +32,9 @@ Toolshed also supports variables in which you can store values. You can use the 
 ```
 {{#include toolshed/explain_example_3.txt}}
 ```
+
+```admonish note
+Toolshed often spits out lengthy stacktraces upon a command being used incorrectly. Typically, there is a more clear error above the stacktrace in your console.
+```
+
+For examples of how to string toolshead commands together see [toolshead examples](./toolshed/toolshed-examples.md)

--- a/src/en/robust-toolbox/toolshed/toolshed-examples.md
+++ b/src/en/robust-toolbox/toolshed/toolshed-examples.md
@@ -1,0 +1,191 @@
+# Toolshed Examples
+
+This guide covers some basic examples of toolshead commands.
+
+## Interacting with entities
+
+Most of the time that you are interacting with toolshead you are manipulating entities in some way.
+
+### Basics
+`ent` is a toolshed command that allows us to return an entity with the provided ENTID. By pipeing the output of the command, we can use it to various things on the entity. Some examples include:
+
+```
+> ent 12345 delete
+```
+Will delete the provided entity
+
+```
+> ent 12345 replace PlushieBee
+```
+Will repalce the entity with the provided prototype, for example, turn it into a bee plushie
+
+```
+> ent 12345 comp:ensure Mindshield comp:rm Electrified comp:rm Airtight
+```
+Will check if the entity has the "Mindshield" component and add it if needed, then remove the Electrified and Airtight components
+
+### Targeting yourself
+
+`self` will always return the entity currently controlled by you.
+
+```
+> self rejuvenate / Will heal your character
+```
+
+### Entity Queries and Filters
+
+`entities` and `nearby` will return either all entities that exist on the server or entities within a provided tile radius of the input entity. Keep in mind that these require the QUERY permission.
+
+```
+> entities
+```
+Will return a list of all entities on the server
+
+```
+> self nearby 20
+```
+Will return all entities in the 20 tile radius of your character
+
+```
+> ent 12345 nearby 3
+```
+Will return all entities in the 3 tile radius of entity 12345
+
+```
+> entities with ZombifyOnDeath visualize
+```
+Will open an UI with all of the infected people on the station, from which you can either VV or TP to them
+```
+> self nearby 20 replace PlushieBee
+```
+Will replace every entity in a 20 tile radius with the provided prototype (in this case `PlushieBee`)
+
+```
+> entities prototyped CableApcExtension delete
+```
+Will delete all LV power cables on the server
+
+The most important commands for filtering the output are as follows:
+
+```
+named "STRING"
+```
+Takes in a list of entities and will filter entities based on their name, this command is compatible with the wildcard `.*`
+
+```
+> entities named ".*cable"
+```
+Will return all entities that end their name with the string "cable"
+
+```
+> entities named ".*power.*"
+```
+Will return all entities that contain the string "power" in their name
+
+```
+with [component]
+```
+Takes a list of entities and only returns entities that have the specified component
+
+```
+> entities with MobState
+```
+Will return all mobs on the server
+
+```
+actor:controlled
+```
+Takes in a list of entities and will return all entities that are currently controlled by a player
+
+```
+> entities actor:controlled tp:to self
+```
+`self` can also be used as an argument - this will teleport all players to your location
+
+```
+select [N]
+```
+Takes in a list of entities and will randomly select n entities from the input
+
+```
+select [N%]
+```
+Takes in a list of entities and will select a percentage of the input
+
+Combining filters together we can do as follows:
+```
+> entities actor:controlled select 5 tp:to self
+```
+Will teleport 5 randomly selected players to the entity you are currently controlling.
+
+## Fun commands
+
+### THE BEES WILL CONTINUE UNTIL MORALE IMPROVES:
+```
+> self rep 10 spawn:on "MobAngryBee" nearby 10 prototyped MobAngryBee select 1 tag:add "DoorBumpOpener" do "makeghostrole $ID \"Queen Bee\" \"Lead the bees!\"" do "rename $ID \"Queen Bee\"" nearby 10 protoyped MobAngryBee not with GhostRole do "makeghostrole $ID \"Angry Bee\" \"You are an angry bee and you want some pizza.\""
+```
+This command can be split into multiple parts for easier understanding:
+
+- We start off by getting our current character with `self`
+- Then for that character we execute the command `spawn:on` 10 times: `rep 10 spawn:on "MobAngryBee"`
+    - The `rep 10` part repeats the command ten times, and the `spawn:on` command will spawn a provided prototype MobAngryBee on the provided entity - here that's self
+- Then we want to fetch everything in a ten tile radius and filter off the bees we spawned with `nearby 10 prototyped MobAngryBee`
+- Once we have all of our bees, we select one of them using `select 1` and add the tag `DoorBumpOpener` using the command `tag:add`
+    - Tags are like components that contain no data, `DoorBumpOpener` allows for opening airlocks by walking into them, just like a player would
+- Next, for the same one bee, we execute the legacy command `makeghostrole` - the first argument is the ID, the second one is the name, the third one is the description. It's important to use the \ symbol before the quotation mark to ensure it is escaped properly.
+- Finally, we rename our bee to "Queen Bee"
+- Then we fetch all nine other bees and also turn them into ghost roles, just like we did with the Queen Bee
+
+Now, a way more efficient way to do this would to have two separate commands, one for the Queen Bee and one for the Angry Bees. This is just a demo of how complex toolshed can get.
+
+### GHOSTULARITY:
+```
+> entities with Singularity comp:ensure MobState comp:ensure MovementIgnoreGravity comp:ensure InputMover comp:ensure MobMover do "makeghostrole $ID \"Singularity\" \"FUCK\""
+```
+
+This command will turn all singulos on the server into player controlled ghost roles
+
+### Bee plushie grenade
+
+Have you ever wanted a bee plushie grenade? You can have one with this simple command!
+```
+> self spawn:on "GrenadeStinger" do "rename $ID \"bee plushie grenade\"" do "vvwrite /entity/$ID/ClusterGrenade/FillPrototype \"PlushieBee\""
+
+```
+You can replace the `FillPrototype` of cluster grenades with any valid Prototype. Keep in mind that any explosives you spawn this way will be activated by default, so you might not want to use it to spawn thirty Holy Hand Grenades.
+
+### Put the station into debt
+
+Salvage keeps powergaming? Put the station in debt with this one simple solution!
+```
+> stations:get do "vvwrite /entity/$ID/StationBankAccount/Balance 1000"
+```
+
+Make sure to replace the 1000 with the balance you want to set
+Alternatively, you could go into F7 > Objects > Stations, check the stations ENTID and then do
+```
+vv /entity/ENTID/StationBankAccount
+```
+
+## Scripts and You
+
+Scripts can be used to automate certain tasks or commands. To create a new script, you will need to create a new file in your Space Station 14 Data directory. On Windows you should be able to find it under %appdata%, in Space Staion 14/data
+
+The file name should be whatever you want the script to be called. You can edit it with any text editor, just make sure to save it as a file with no extension.
+
+Admins will often have a script to customize their ghosts. Here is an example of one:
+
+```
+> self not prototyped AdminObserver do "aghost"
+> self comp:ensure ShowCriminalRecordIcons comp:ensure ShowJobIcons comp:ensure ShowJobIcons comp:ensure ShowMindShieldIcons comp:ensure ShowSyndicateIcons comp:ensure Grammar comp:ensure Identity
+> self do "vvwrite entity/$ID/Ghost/color '#00D2AD'"
+> self do "vvwrite entity/$ID/Description \"GHOST GANG!!\""
+> self do "vvwrite entity/$ID/Grammar/Attributes[gender] Male"
+```
+
+- The first line makes sure you are an admin ovserver
+- Next, we make sure to add any of the components that are helpful for adminning if needed. These show up the job icons, antag icons, mindshields. The `Grammar` and `Identity` components are used later for customizing the aghost
+- The third and fourth line set the ghost color and description using `vvwrite` with a path and a value
+- The last line changes the pronouns to show up as He whenever someone inspects the ghost.
+
+When you want to run the script in game, all you have to do is use the exec command. If you called the above script "admin", you would run the command `exec /admin`

--- a/src/en/robust-toolbox/toolshed/toolshed-examples.md
+++ b/src/en/robust-toolbox/toolshed/toolshed-examples.md
@@ -178,7 +178,7 @@ Admins will often have a script to customize their ghosts. Here is an example of
 
 ```
 > self not prototyped AdminObserver do "aghost"
-> self comp:ensure ShowCriminalRecordIcons comp:ensure ShowJobIcons comp:ensure ShowJobIcons comp:ensure ShowMindShieldIcons comp:ensure ShowSyndicateIcons comp:ensure Grammar comp:ensure Identity
+> self comp:ensure ShowCriminalRecordIcons comp:ensure ShowJobIcons comp:ensure ShowMindShieldIcons comp:ensure ShowSyndicateIcons comp:ensure Grammar comp:ensure Identity
 > self do "vvwrite entity/$ID/Ghost/color '#00D2AD'"
 > self do "vvwrite entity/$ID/Description \"GHOST GANG!!\""
 > self do "vvwrite entity/$ID/Grammar/Attributes[gender] Male"

--- a/src/en/robust-toolbox/toolshed/toolshed-examples.md
+++ b/src/en/robust-toolbox/toolshed/toolshed-examples.md
@@ -170,7 +170,7 @@ vv /entity/ENTID/StationBankAccount
 
 ## Scripts and You
 
-Scripts can be used to automate certain tasks or commands. To create a new script, you will need to create a new file in your Space Station 14 Data directory. On Windows you should be able to find it under `%appdata%`, in `Space Staion 14/data`.
+Scripts can be used to automate certain tasks or commands. To create a new script, you will need to create a new file in your Space Station 14 [client data directory](../user-data-directory.md#Client).
 
 The file name should be whatever you want the script to be called. You can edit it with any text editor, just make sure to save it as a file with no extension.
 

--- a/src/en/robust-toolbox/toolshed/toolshed-examples.md
+++ b/src/en/robust-toolbox/toolshed/toolshed-examples.md
@@ -12,17 +12,17 @@ Most of the time that you are interacting with toolshead you are manipulating en
 ```
 > ent 12345 delete
 ```
-Will delete the provided entity
+Will delete the provided entity.
 
 ```
 > ent 12345 replace PlushieBee
 ```
-Will repalce the entity with the provided prototype, for example, turn it into a bee plushie
+Will repalce the entity with the provided prototype, for example, turn it into a bee plushie.
 
 ```
 > ent 12345 comp:ensure Mindshield comp:rm Electrified comp:rm Airtight
 ```
-Will check if the entity has the "Mindshield" component and add it if needed, then remove the Electrified and Airtight components
+Will check if the entity has the "Mindshield" component and add it if needed, then remove the Electrified and Airtight components.
 
 ### Targeting yourself
 
@@ -39,78 +39,79 @@ Will check if the entity has the "Mindshield" component and add it if needed, th
 ```
 > entities
 ```
-Will return a list of all entities on the server
+Will return a list of all entities on the server.
 
 ```
 > self nearby 20
 ```
-Will return all entities in the 20 tile radius of your character
+Will return all entities in the 20 tile radius of your character.
 
 ```
 > ent 12345 nearby 3
 ```
-Will return all entities in the 3 tile radius of entity 12345
+Will return all entities in the 3 tile radius of entity 12345.
 
 ```
 > entities with ZombifyOnDeath visualize
 ```
-Will open an UI with all of the infected people on the station, from which you can either VV or TP to them
+Will open an UI with all of the infected people on the station, from which you can either VV or TP to them.
+
 ```
 > self nearby 20 replace PlushieBee
 ```
-Will replace every entity in a 20 tile radius with the provided prototype (in this case `PlushieBee`)
+Will replace every entity in a 20 tile radius with the provided prototype (in this case `PlushieBee`).
 
 ```
 > entities prototyped CableApcExtension delete
 ```
-Will delete all LV power cables on the server
+Will delete all LV power cables on the server.
 
 The most important commands for filtering the output are as follows:
 
 ```
 named "STRING"
 ```
-Takes in a list of entities and will filter entities based on their name, this command is compatible with the wildcard `.*`
+Takes in a list of entities and will filter entities based on their name, this command is compatible with the wildcard `.*`.
 
 ```
 > entities named ".*cable"
 ```
-Will return all entities that end their name with the string "cable"
+Will return all entities that end their name with the string "cable".
 
 ```
 > entities named ".*power.*"
 ```
-Will return all entities that contain the string "power" in their name
+Will return all entities that contain the string "power" in their name.
 
 ```
 with [component]
 ```
-Takes a list of entities and only returns entities that have the specified component
+Takes a list of entities and only returns entities that have the specified component.
 
 ```
 > entities with MobState
 ```
-Will return all mobs on the server
+Will return all mobs on the server.
 
 ```
 actor:controlled
 ```
-Takes in a list of entities and will return all entities that are currently controlled by a player
+Takes in a list of entities and will return all entities that are currently controlled by a player.
 
 ```
 > entities actor:controlled tp:to self
 ```
-`self` can also be used as an argument - this will teleport all players to your location
+`self` can also be used as an argument - this will teleport all players to your location.
 
 ```
 select [N]
 ```
-Takes in a list of entities and will randomly select n entities from the input
+Takes in a list of entities and will randomly select n entities from the input.
 
 ```
 select [N%]
 ```
-Takes in a list of entities and will select a percentage of the input
+Takes in a list of entities and will select a percentage of the input.
 
 Combining filters together we can do as follows:
 ```
@@ -126,15 +127,15 @@ Will teleport 5 randomly selected players to the entity you are currently contro
 ```
 This command can be split into multiple parts for easier understanding:
 
-- We start off by getting our current character with `self`
-- Then for that character we execute the command `spawn:on` 10 times: `rep 10 spawn:on "MobAngryBee"`
-    - The `rep 10` part repeats the command ten times, and the `spawn:on` command will spawn a provided prototype MobAngryBee on the provided entity - here that's self
-- Then we want to fetch everything in a ten tile radius and filter off the bees we spawned with `nearby 10 prototyped MobAngryBee`
-- Once we have all of our bees, we select one of them using `select 1` and add the tag `DoorBumpOpener` using the command `tag:add`
-    - Tags are like components that contain no data, `DoorBumpOpener` allows for opening airlocks by walking into them, just like a player would
+- We start off by getting our current character with `self`.
+- Then for that character we execute the command `spawn:on` 10 times: `rep 10 spawn:on "MobAngryBee"`.
+    - The `rep 10` part repeats the command ten times, and the `spawn:on` command will spawn a provided prototype MobAngryBee on the provided entity - here that's self.
+- Then we want to fetch everything in a ten tile radius and filter off the bees we spawned with `nearby 10 prototyped MobAngryBee`.
+- Once we have all of our bees, we select one of them using `select 1` and add the tag `DoorBumpOpener` using the command `tag:add`.
+    - Tags are like components that contain no data, `DoorBumpOpener` allows for opening airlocks by walking into them, just like a player would.
 - Next, for the same one bee, we execute the legacy command `makeghostrole` - the first argument is the ID, the second one is the name, the third one is the description. It's important to use the \ symbol before the quotation mark to ensure it is escaped properly.
-- Finally, we rename our bee to "Queen Bee"
-- Then we fetch all nine other bees and also turn them into ghost roles, just like we did with the Queen Bee
+- Finally, we rename our bee to "Queen Bee".
+- Then we fetch all nine other bees and also turn them into ghost roles, just like we did with the Queen Bee.
 
 Now, a way more efficient way to do this would be to have two separate commands, one for the Queen Bee and one for the Angry Bees. This is just a demo of how complex toolshed can get.
 
@@ -143,7 +144,7 @@ Now, a way more efficient way to do this would be to have two separate commands,
 > entities with Singularity comp:ensure MobState comp:ensure MovementIgnoreGravity comp:ensure InputMover comp:ensure MobMover do "makeghostrole $ID \"Singularity\" \"FUCK\""
 ```
 
-This command will turn all singulos on the server into player controlled ghost roles
+This command will turn all singulos on the server into player controlled ghost roles.
 
 ### Bee plushie grenade
 
@@ -160,16 +161,16 @@ Salvage keeps powergaming? Put the station in debt with this one simple solution
 ```
 > stations:get do "vvwrite /entity/$ID/StationBankAccount/Balance 1000"
 ```
+Make sure to replace the 1000 with the balance you want to set.
 
-Make sure to replace the 1000 with the balance you want to set
-Alternatively, you could go into F7 > Objects > Stations, check the stations ENTID and then do
+Alternatively, you could go into F7 > Objects > Stations, check the stations ENTID and then do:
 ```
 vv /entity/ENTID/StationBankAccount
 ```
 
 ## Scripts and You
 
-Scripts can be used to automate certain tasks or commands. To create a new script, you will need to create a new file in your Space Station 14 Data directory. On Windows you should be able to find it under %appdata%, in Space Staion 14/data
+Scripts can be used to automate certain tasks or commands. To create a new script, you will need to create a new file in your Space Station 14 Data directory. On Windows you should be able to find it under `%appdata%`, in `Space Staion 14/data`.
 
 The file name should be whatever you want the script to be called. You can edit it with any text editor, just make sure to save it as a file with no extension.
 
@@ -185,7 +186,7 @@ Admins will often have a script to customize their ghosts. Here is an example of
 
 - The first line makes sure you are an admin observer.
 - Next, we make sure to add any of the components that are helpful for admining if needed. These show up the job icons, antag icons, mindshields. The `Grammar` and `Identity` components are used later for customizing the aghost.
-- The third and fourth line set the ghost color and description using `vvwrite` with a path and a value
+- The third and fourth line set the ghost color and description using `vvwrite` with a path and a value.
 - The last line changes the pronouns to show up as He whenever someone inspects the ghost.
 
-When you want to run the script in game, all you have to do is use the exec command. If you called the above script "admin", you would run the command `exec /admin`
+When you want to run the script in game, all you have to do is use the exec command. If you called the above script "admin", you would run the command `exec /admin`.

--- a/src/en/robust-toolbox/toolshed/toolshed-examples.md
+++ b/src/en/robust-toolbox/toolshed/toolshed-examples.md
@@ -1,6 +1,6 @@
 # Toolshed Examples
 
-This guide covers some basic examples of toolshead commands.
+This guide covers some basic examples of Toolshed commands.
 
 ## Interacting with entities
 
@@ -136,7 +136,7 @@ This command can be split into multiple parts for easier understanding:
 - Finally, we rename our bee to "Queen Bee"
 - Then we fetch all nine other bees and also turn them into ghost roles, just like we did with the Queen Bee
 
-Now, a way more efficient way to do this would to have two separate commands, one for the Queen Bee and one for the Angry Bees. This is just a demo of how complex toolshed can get.
+Now, a way more efficient way to do this would be to have two separate commands, one for the Queen Bee and one for the Angry Bees. This is just a demo of how complex toolshed can get.
 
 ### GHOSTULARITY:
 ```
@@ -183,8 +183,8 @@ Admins will often have a script to customize their ghosts. Here is an example of
 > self do "vvwrite entity/$ID/Grammar/Attributes[gender] Male"
 ```
 
-- The first line makes sure you are an admin ovserver
-- Next, we make sure to add any of the components that are helpful for adminning if needed. These show up the job icons, antag icons, mindshields. The `Grammar` and `Identity` components are used later for customizing the aghost
+- The first line makes sure you are an admin observer.
+- Next, we make sure to add any of the components that are helpful for admining if needed. These show up the job icons, antag icons, mindshields. The `Grammar` and `Identity` components are used later for customizing the aghost.
 - The third and fourth line set the ghost color and description using `vvwrite` with a path and a value
 - The last line changes the pronouns to show up as He whenever someone inspects the ghost.
 


### PR DESCRIPTION
This PR includes some minor alterations to the introduction to toolshead and
adds a ton of examples for how to use toolshead. The examples are all from
"Milon's Guide to Toolshed" which has been privately shared for some time. The
content was published with permission from the author. It was originally
targeted at game admins, however should also be useful to developers.
