### PR TITLE
Add caddy and docker compose to robustcdn

### DIFF
--- a/src/en/server-hosting/setting-up-robust-cdn.md
+++ b/src/en/server-hosting/setting-up-robust-cdn.md
@@ -57,6 +57,24 @@ The latest stable image of Robust.Cdn is `ghcr.io/space-wizards/robust.cdn:2`. I
   * `/manifest`: contains SQLite database for server manifest operations.
   * `/database`: contains SQLite database for client content downloads.
 
+Here is an example ``docker-compose.yml``, please modify it to your needs.
+
+```
+services:
+  robust_cdn:
+    image: ghcr.io/space-wizards/robust.cdn:2
+    container_name: robust_cdn
+    user: 1654:1654
+    volumes:
+      - ./appsettings.json:/app/appsettings.json
+      - ./builds:/builds
+      - ./manifest:/manifest
+      - ./database:/database
+    ports:
+      - 8080:8080
+    restart: unless-stopped
+```
+
 ### Manual compilation
 
 If you hate containers, you can manually publish Robust.Cdn and deploy the files yourself. For this you will need Git and the .NET 8 SDK. The server that will run the build needs the matching ASP.NET Core Runtime installed, but does not need the SDK itself.
@@ -225,7 +243,7 @@ You should go over this config file in full to understand what you are setting u
 
 If your fork's repository is hosted on GitHub, the easiest way to automatically publish new builds to Robust.Cdn is via the GitHub Actions configuration available in the codebase. This is how official Wizard's Den builds are published.
 
-1. Edit `Tools/publish_github_artifact.py` to modify the "configuration parameters" at the top of the script:
+1. Edit `Tools/publish_multi_request.py` to modify the "configuration parameters" at the top of the script:
   * `ROBUST_CDN_URL` should be the URL at which Robust.Cdn is accessible.
   * `FORK_ID` should be the ID of the fork you configured in `appsettings.json`
 
@@ -354,6 +372,23 @@ location / {
     # Update port here.
     proxy_pass         http://localhost:8080;
 }
+```
+
+### Caddy
+
+This is an example Caddyfile to go into an existing block for the domain with the CDN
+
+```
+# Increased max body size for multi-request publishes.
+request_body {
+        max_size 512MB
+}
+
+reverse_proxy localhost:8080 {
+        flush_interval -1
+}
+
+encode zstd gzip
 ```
 
 ## Troubleshooting

--- a/src/en/server-hosting/setting-up-robust-cdn.md
+++ b/src/en/server-hosting/setting-up-robust-cdn.md
@@ -388,7 +388,9 @@ reverse_proxy localhost:8080 {
         flush_interval -1
 }
 
-encode zstd gzip
+encode zstd gzip {
+    match header Content-Type application/json*
+}
 ```
 
 ## Troubleshooting

--- a/src/en/server-hosting/setting-up-robust-cdn.md
+++ b/src/en/server-hosting/setting-up-robust-cdn.md
@@ -376,7 +376,7 @@ location / {
 
 ### Caddy
 
-This is an example Caddyfile to go into an existing block for the domain with the CDN
+This is an example Caddyfile to go into an existing block for the domain with the CDN. If you are putting this in a path you can just put all these under the path.
 
 ```
 # Increased max body size for multi-request publishes.
@@ -384,10 +384,12 @@ request_body {
         max_size 512MB
 }
 
+# Update port here.
 reverse_proxy localhost:8080 {
         flush_interval -1
 }
 
+# Compress JSON responses.
 encode zstd gzip {
     match header Content-Type application/json*
 }

--- a/src/en/server-hosting/setting-up-robust-cdn.md
+++ b/src/en/server-hosting/setting-up-robust-cdn.md
@@ -75,6 +75,14 @@ services:
     restart: unless-stopped
 ```
 
+You may have to run these commands to set the correct owner and permissions for the ``builds``, ``manifest`` and ``database`` folders.
+
+```
+sudo chown -R 1654:1654 builds/ database/ manifest/
+sudo chmod -R u+w,g+w builds/ database/ manifest/
+```
+
+
 ### Manual compilation
 
 If you hate containers, you can manually publish Robust.Cdn and deploy the files yourself. For this you will need Git and the .NET 8 SDK. The server that will run the build needs the matching ASP.NET Core Runtime installed, but does not need the SDK itself.

--- a/src/en/server-hosting/setting-up-robust-cdn.md
+++ b/src/en/server-hosting/setting-up-robust-cdn.md
@@ -381,12 +381,12 @@ This is an example Caddyfile to go into an existing block for the domain with th
 ```
 # Increased max body size for multi-request publishes.
 request_body {
-        max_size 512MB
+    max_size 512MB
 }
 
 # Update port here.
 reverse_proxy localhost:8080 {
-        flush_interval -1
+    flush_interval -1
 }
 
 # Compress JSON responses.


### PR DESCRIPTION
Caddy's reverse config may not need the [flush_interval](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#flush_interval) value, since it will automatically instantly flush if ``Content-Length`` is non-existent (my quick read thru the publishing code looks like it does not?)

~~Looking into why the dockercompose won't work without perm fixes~~

~~Encode works for the whole reverse proxy block and not just json~~