### PR TITLE
Update maintainer policy

### DIFF
--- a/src/en/staff/maintainer-policy.md
+++ b/src/en/staff/maintainer-policy.md
@@ -8,11 +8,14 @@ This does not apply to rule change PRs from the Head Game Admins.
 - **If in doubt, continue with the procedure and ping anyways.**
 
 You **MUST**:
-- Link the PR in [#maint-review-pings](https://discord.com/channels/310555209753690112/1258585578618884167) AND ping any relevant Design Work Groups for review.
+- Link the PR in [#maint-review](https://discord.com/channels/310555209753690112/1262608966555271289), add labels on the discord post AND ping any relevant Design Work Groups for review.
+- Pin the original message for easy scrolling to the top of the conversation.
+- Add the "Undergoing Maintainer Discussion" label to the PR
 If this PR may affect game admins too (rules, rule clarifications, round flow, etc) **all Head Game Admins must be pinged as well.**
   - **If you are not sure, ping Head Game Admins anyways.**
   - It is up to anyone organizing work groups to create a new one if relevant.
     - **If a new work group is created due to this, a further 24 hours are added to this process.**
+- Any polls, or anything seeming important should be pinned.
 - The PR must have at least one **Maintainer** approving it, and at least 3 days must have passed since you pinged the relevant Design Groups, and Game Admins if applicable in that channel, with no one dissenting to merging said PR.
 - Once the time is up:
   - If no one dissents, the PR can be merged.
@@ -20,10 +23,11 @@ If this PR may affect game admins too (rules, rule clarifications, round flow, e
     - **These opinions must be communicated in a neutral manner, even if you disagree with them.**
   - This is the case even if only one person dissents.
   - Once addressed by the PR author, the process may be started again.
-  - If a deadlock is reached where one or more people's dissents cannot be resolved, **a 24-hour-long poll** must be made in the channel with **another @Review Pings + Work Groups + Head Game Admin (if relevant) ping**.
+  - If a deadlock is reached where one or more people's dissents cannot be resolved, **a 24-hour-long poll** must be made in the channel with **another Work Groups + Head Game Admin (if relevant) ping**.
   - At least **75% or more of voters** must agree to it being merged before it does.
     - There is no veto power from any role in the project.
   - If less than 75% of people vote to merge the PR, it must be discussed again and the PR author must be notified.
   - If after another 48 hours no poll reaches 75% or more approvals, the PR may be closed.
+  - (Optional but recommended) Edit the discord post to have "[MERGED]" or "[CLOSED]" and give it the proper label for that.
 
 **Breaking any of these rules may result in an instant demotion from Maintainer.**

--- a/src/en/staff/maintainer-policy.md
+++ b/src/en/staff/maintainer-policy.md
@@ -28,6 +28,6 @@ If this PR may affect game admins too (rules, rule clarifications, round flow, e
     - There is no veto power from any role in the project.
   - If less than 75% of people vote to merge the PR, it must be discussed again and the PR author must be notified.
   - If after another 48 hours no poll reaches 75% or more approvals, the PR may be closed.
-  - (Optional but recommended) Edit the discord post to have "[MERGED]" or "[CLOSED]" and give it the proper label for that.
+  - (Optional but recommended) Edit the discord post to have "[MERGED]", "[CLOSED]" or "[DERELICT]/[AWAITING CHANGES]" and give it the proper label for that.
 
 **Breaking any of these rules may result in an instant demotion from Maintainer.**


### PR DESCRIPTION
I got permission to edit this.

Changelog:
- Edited discord link
- More information about adding discord tags to the threads
- Adding maint review label on GitHub.
- Reminding to pin the message and anything important such as pings
- Removing the retired review ping role from the docs
- Encourage editing the prefix for easier scrolling