### PR TITLE
Add Warning to Pull Requests in Tutorial

### DIFF
--- a/src/en/general-development/setup/git-for-the-ss14-developer.md
+++ b/src/en/general-development/setup/git-for-the-ss14-developer.md
@@ -450,7 +450,7 @@ Now, the fun part. We'll go to GitHub now and make a pull request for our funny 
 Add a description, a nice title, some screenshots, and hopefully it gets merged.
 
 ```admonish warning title="Don't do it now"
-Your pull request will be made directly in the official repository and will be visible to others. Ensure that your changes are thoroughly reviewed and ready for official evaluation. If you only want to test, create the PR in your own fork to avoid making it publicly visible.
+Any pull request made to the official repository will be publicly visible and open for review and comments by anyone. Ensure that your changes are thoroughly reviewed and ready for official evaluation. If you only want to test, consider creating the PR in your own fork.
 ```
 
 ## 6. Updating our repository

--- a/src/en/general-development/setup/git-for-the-ss14-developer.md
+++ b/src/en/general-development/setup/git-for-the-ss14-developer.md
@@ -449,6 +449,10 @@ Now, the fun part. We'll go to GitHub now and make a pull request for our funny 
 
 Add a description, a nice title, some screenshots, and hopefully it gets merged.
 
+```admonish warning title="Don't do it now"
+Your pull request will be made directly in the official repository and will be visible to others. Ensure that your changes are thoroughly reviewed and ready for official evaluation. If you only want to test, create the PR in your own fork to avoid making it publicly visible.
+```
+
 ## 6. Updating our repository
 
 Maybe it's been a while, a week or two, since your last pull request, and you'd like to make another. Before you do anything, you need to download (**pull**) the code changes from the main SS14 repository into your local repository. If you don't, you'll have out-of-date code and your local changes may not be accurate to how the game will actually run--you might even get **merge conflicts** when you try to PR.


### PR DESCRIPTION
This pull request adds a warning to the documentation about pull requests in the official repository.
It highlights that changes will be public and advises developers to review their work carefully.
Additionally, it suggests using personal forks for testing to keep changes private.
This helps prevent confusion and clarifies the process for future contributors.

Note: I made this mistake myself, and I hope this warning helps others avoid the same issue.

Link: [Documentation](https://docs.spacestation14.com/en/general-development/setup/git-for-the-ss14-developer.html#52-making-a-pull-request)

![grafik](https://github.com/user-attachments/assets/9494d2f1-063c-4c92-bf79-f11c9d3b6edb)

I used the code-block from [3. Setting up remotes](https://docs.spacestation14.com/en/general-development/setup/git-for-the-ss14-developer.html#3-setting-up-remotes)
so visually it should look like this:

![grafik](https://github.com/user-attachments/assets/2f6586cc-d189-45d8-afad-e039f755d25a)
