### PR TITLE
Atmos Proposal - Whole Station Air Recirculation (HVAC)

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -201,6 +201,7 @@ Space Station 14
 
 		- [Proposals]()
 			- [Atmos Rework](en/space-station-14/departments/atmos/proposals/atmos-rework.md)
+            - [Station Air Recirculation](/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md)
 
 	- [Cargo/Salvage](en/space-station-14/departments/cargo-salvage.md)
 		- [PR Guidelines](en/space-station-14/departments/cargo-salvage/guidelines.md)

--- a/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
+++ b/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
@@ -99,23 +99,23 @@ Major changes are required to station setups, but the core systems are already p
 
 ### Benefits (Arguments for the implementation)
 1. **Proper atmospheric flow.**
-  - This system allows for true, flow-based atmospherics (HVAC) which is a highly complex system, present in real life. This gives Atmos another level of depth and distracts away from sitting in the department waiting for something to happen.
+   - This system allows for true, flow-based atmospherics (HVAC) which is a highly complex system, present in real life. This gives Atmos another level of depth and distracts away from sitting in the department waiting for something to happen.
 2. **Station-wide temperature control.**
-  - This system allows for the proper control of station temperature, which is currently a huge issue. Atmos currently has no easy way to modify the station temperature en-masse.
+   - This system allows for the proper control of station temperature, which is currently a huge issue. Atmos currently has no easy way to modify the station temperature en-masse.
 3. **Emergent gameplay based on the Ideal Gas Law.**
-  - Savvy Atmos techs can take advantage of the Ideal Gas Law to create interesting solutions to station problems. For example, the station's temperature can be increased slightly to increase the effective pressure of the station's air, helping to alleviate a potential gas shortage before more gas is acquired.
+   - Savvy Atmos techs can take advantage of the Ideal Gas Law to create interesting solutions to station problems. For example, the station's temperature can be increased slightly to increase the effective pressure of the station's air, helping to alleviate a potential gas shortage before more gas is acquired.
 4. **Centralization of station waste gas removal.**
-  - Gas circulation means that all gasses, including waste gasses, are sent to the recyclernet, enabling recycling on a station-wide level, not a room-by-room level.
+   - Gas circulation means that all gasses, including waste gasses, are sent to the recyclernet, enabling recycling on a station-wide level, not a room-by-room level.
 5. **Gives Atmos a proper system to manage and keep watch.**
-  - Atmos now has to oversee the station's temperature and gas reserves, which requires constant monitoring and maintaining.
-  - Engineering, in comparison, has the power of overseeing station power, a system which requires constant monitoring and maintaining (singulo gas tank refilling, tesla coil repairs).
+   - Atmos now has to oversee the station's temperature and gas reserves, which requires constant monitoring and maintaining.
+     - Engineering, in comparison, has the power of overseeing station power, a system which requires constant monitoring and maintaining (singulo gas tank refilling, tesla coil repairs).
 6. **Moves away from infinite gas.**
-  - This system moves away from infinite gas, which is a huge issue in the current atmos system and is a goal in the **Atmos Roadmap**.
-  - As previously mentioned, Atmos techs can space and refill rooms with zero consequence of wasting gas. All problems with bad air can be inherently fixed by just replacing the room's air.
+   - This system moves away from infinite gas, which is a huge issue in the current atmos system and is a goal in the **Atmos Roadmap**.
+   - As previously mentioned, Atmos techs can space and refill rooms with zero consequence of wasting gas. All problems with bad air can be inherently fixed by just replacing the room's air.
 7. **Encourages the usage of Frezon gas in radiator loops.**
-  - In the future, Frezon can be used as a highly effective working gas for use in radiator loops. Cooling and heating an entire station requires a lot of energy and work to be done. Normal gasses might not have thermal properties good enough for conducting heat fast enough.
+   - In the future, Frezon can be used as a highly effective working gas for use in radiator loops. Cooling and heating an entire station requires a lot of energy and work to be done. Normal gasses might not have thermal properties good enough for conducting heat fast enough.
 8. **More agency for antagonists.**
-  - Antagonists can now sabotage the station's air supply, which can lead to a station-wide crisis. This can be used to create interesting rounds and scenarios. However, the ease at which this can be accomplished presents greater issues, explained in Drawbacks.
+   - Antagonists can now sabotage the station's air supply, which can lead to a station-wide crisis. This can be used to create interesting rounds and scenarios. However, the ease at which this can be accomplished presents greater issues, explained in Drawbacks.
 9. **Encourages greater care with station atmos setups and adds value to gasses.**
    - With this change, all gasses are now extremely valuable. Spacing a room's air is no longer a viable solution, as the station's air reserves are no longer infinite. Atmos techs now have to take extra care and ensure that holes are fully patched before filling a room.
    - This will also lead to Atmos taking great care to ensure that further gas does not escape to space when moving between firelocks. This reinforces the usage of holofans.
@@ -123,34 +123,35 @@ Major changes are required to station setups, but the core systems are already p
    - This change also encourages Atmos to spend more time ensuring their setups are correct, as a mistake could lead to wasting precious gas or dealing with an expensive-to-fix mess.
 ### Drawbacks (Arguments against the implementation)
 1. **Potential for easy and devastating mass station sabotage.**
-  - While it could be argued that this could lead to emergent gameplay and hostage roleplay, it could also lead to 5 minute rounds.
-  - All air returns to a central location, so it is incredibly easy to simply replace all of the air with a harmful gas (carbon dioxide or pure nitrogen).
-  - The entire station's temperature is controlled by two air alarms. It is very easy to sabotage these air alarms and deep fry or freeze the station.
-    - This has some implications for the future Malfunctioning AI gamemode, as they can easily sabotage the station's air supply under Atmos' nose (superheating/supercooling), although this instantly outs the AI and the crew will work to kill the AI posthaste.
-  - This has some counterarguments, though:
-    - Mass station sabotage is prohibited by the rules. Familiarly, mass sabotage like this isn't exactly a huge undertaking, similar to someone snipping wires on a Tesla/Singularity containment.
-    - Because of the flow-based nature of the system, it is possible to detect and fix the sabotage by simply undoing the sabotage. However, half the station could be dead by the time this is done. What are you gonna do? Un-steam half of the station?
-  - This proposal introduces another source of mass station sabotage with a very neutral counterbalance. Right now, changes should be working towards the goal of making mass station sabotage before the 30-minute mark harder.
+   - While it could be argued that this could lead to emergent gameplay and hostage roleplay, it could also lead to 5 minute rounds.
+     - All air returns to a central location, so it is incredibly easy to simply replace all of the air with a harmful gas (carbon dioxide or pure nitrogen).
+     - The entire station's temperature is controlled by two air alarms. It is very easy to sabotage these air alarms and deep fry or freeze the station.
+       - This has some implications for the future Malfunctioning AI gamemode, as they can easily sabotage the station's air supply under Atmos' nose (superheating/supercooling), although this instantly outs the AI and the crew will work to kill the AI posthaste.
+     - This has some counterarguments, though:
+       - Mass station sabotage is prohibited by the rules. Familiarly, mass sabotage like this isn't exactly a huge undertaking, similar to someone snipping wires on a Tesla/Singularity containment.
+       - Because of the flow-based nature of the system, it is possible to detect and fix the sabotage by simply undoing the sabotage. However, half the station could be dead by the time this is done. What are you gonna do? Un-steam half of the station?
+     - This proposal introduces another source of mass station sabotage with a very neutral counterbalance. Right now, changes should be working towards the goal of making mass station sabotage before the 30-minute mark harder.
 2. **Potential performance issues from mass gas flow.**
-  - This system introduces a lot of gas flow by design, which could potentially cause performance issues. The atmospherics system should be properly tested to see if servers can properly handle the load, and optimized if necessary.
+   - This system introduces a lot of gas flow by design, which could potentially cause performance issues. The atmospherics system should be properly tested to see if servers can properly handle the load, and optimized if necessary.
 3. **Reduced oxygen available for burn chambers.**
-  - With the tuning of Gas Miners, the station's oxygen supply is now less infinite. This could potentially lead to a lack of oxygen for burn chambers, which could be a problem for the station's power supply. We want to promote the usage of the Thermo-Electric Generator (TEG) as a power source, and this could potentially hamper that.
-  - This could also hamper the production of Frezon, something we still want to promote.
-  - Obviously, I'm just outlining this as a point that this is something that requires tuning. We want to make burn chambers possible for Frezon production and the TEG, whilst preventing the circumvention of the HVAC system. 
+   - With the tuning of Gas Miners, the station's oxygen supply is now less infinite. This could potentially lead to a lack of oxygen for burn chambers, which could be a problem for the station's power supply. We want to promote the usage of the Thermo-Electric Generator (TEG) as a power source, and this could potentially hamper that.
+     - This could also hamper the production of Frezon, something we still want to promote.
+     - Obviously, I'm just outlining this as a point that this is something that requires tuning. We want to make burn chambers possible for Frezon production and the TEG, whilst preventing the circumvention of the HVAC system. 
 
 ## Future Systems
 
 In the future, the following systems could be implemented to further enhance the station's atmospherics simulation, to encourage the setup of whole-station HVAC:
 1. **All lifeforms radiate heat into the atmosphere.**
-  - Now that the station's air is temperature-controlled, lifeforms can radiate heat into the atmosphere. This encourages the setup of HVAC, as the station's air will naturally heat up over time, making the station stuffier over time.
-  - To encourage this even further, we could introduce a system where lifeforms experience further discomfort if the station's air is too hot or too cold (rather than simply taking damage).
-2. **All lifeforms sweat (or otherwise emit/exhale water vapor).**
-  - Now that the station's air is recirculating and managed at a central place, lifeforms can sweat, which will increase the humidity of the station's air.
-  - This could warrant the creation of a humidity system, which could be used to further enhance the depth of the atmospherics system.
-  - This could also be used to create a system where lifeforms experience further discomfort if the station's air is too humid or too dry, which could give Atmos another aspect of air to manage.
-  - This system could have parallels with the current presence of water vapor.
+   - Now that the station's air is temperature-controlled, lifeforms should radiate heat into the atmosphere. This encourages the setup of HVAC, as the station's air will naturally heat up over time, making the station stuffier over time.
+   - To encourage this even further, we could introduce a system where lifeforms experience further discomfort if the station's air is too hot or too cold (rather than simply taking damage).
+2. **The creation of a humidity system.**
+   - A humidity system could be implemented that further expands the depth of the atmospherics system.
+     - Humidity could have interactions with how temperature is felt by organics and objects.
+     - Humidity could be visualized by the appearance of fog in the station's air in cold areas (in spacing, for example), or the appearance of condensation on windows.
+   - Lifeforms should be able to sweat or exhale water vapor, which will increase the humidity of the station's air.
+     - This could also be used to create a system where lifeforms experience further discomfort if the station's air is too humid or too dry, which could give Atmos another aspect of air to manage.
 3. **Advanced programmable computers that can preform complex logic.**
-  - Managing temperature and pressure is complex for air alarms. A computer system could be implemented to handle the valve-based control of cooling and heating station air.
-  - This can also enable the precise regulation of pumps to control the specific power of heating and cooling.
-    - This is **exactly** what modern thermostats and air conditioning units do in real life to increase efficiency and reduce energy consumption. Rather than running an AC compressor at full power, the compressor is run at a lower power to maintain a specific temperature.
-  - This system has **huge** potential for emergent gameplay, as savvy Atmos techs can use applied mathematics (Ideal Gas Law, Thermodynamics, Specific Heat Capacity, Energy In/Out) to create complex solutions to station problems.
+   - Managing temperature and pressure is complex for air alarms. A computer system could be implemented to handle the valve-based control of cooling and heating station air.
+   - This can also enable the precise regulation of pumps to control the specific power of heating and cooling.
+     - This is **exactly** what modern thermostats and air conditioning units do in real life to increase efficiency and reduce energy consumption. Rather than running an AC compressor at full power, the compressor is run at a lower power to maintain a specific temperature.
+   - This system has **huge** potential for emergent gameplay, as savvy Atmos techs can use applied mathematics (Ideal Gas Law, Thermodynamics, Specific Heat Capacity, Energy In/Out) to create complex solutions to station problems.

--- a/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
+++ b/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
@@ -1,0 +1,129 @@
+# Station Air Recirculation (HVAC)
+
+| Designers      | Implemented | GitHub Links |
+|----------------|---|---|
+| ArtisticRoomba | :x: No | TBD |
+
+## Background
+
+Currently, Space Station 14 Atmos handles air on a replenishment system: air is simply stale in a room and its upkeep is managed by scrubbing waste gases, and replenishing air if it's lost.
+
+This is okay, but this system falls apart when atmospheres experience temperature and pressure upsets, as the air in the station is not recirculated.
+
+## Proposal
+
+This proposal plans to introduce a pressure-based recirculation system, where temperature controlled air can recirculate to maintain a stable atmosphere. Air will flow from a slightly higher pressure air vent (at 110.325 kPa for example) and move to lower pressure air scrubbers. This gas is then recycled, temperature-controlled, and reintroduced into the atmosphere through Distro.
+
+This proposal also plans to remove Gas Miners, as they are no longer needed with the new system.
+
+## The Problem
+
+Currently, air scrubbers **do not** regulate a room's pressure; they simply regulate the waste gasses in the atmosphere. This is a huge problem, as with a lack of pressure regulation, a room can easily become dangerous with a simple temperature change. Take the two examples below:
+
+1. Heat-based temperature upsets. This includes things like fire anomalies, hyper-convection lathes, and lit plasma/tritium.
+2. Cold-based temperature upsets. This includes things like ice anomalies, frezon, and room spacing.
+
+In the event of a heat-based temperature upset, an air scrubber will simply scrub the high-pressure waste gasses and nothing else.
+An atmos tech has to manually drag a station heater and set it up in the area (a machine that some stations don't even have roundstart) to fix the problem.
+The solution most techs execute is to simply space the gas and refill the room with fresh air. The panic mode on scrubbers is not viable, as it simply operates too slowly compared to RCDing a hole into space.
+**This is not viable given the current atmos roadmap (no infinite gas), as we are actively spacing useful gasses!**
+
+In the event of a cold-based temperature upset, air will cool and lose pressure, causing more gas to replace the present vacuum.
+This often leads to a room being made too cold for reptilians (and soon most other species given more time).
+This also leads to more gas entering the room, which drains the station's air reserves (if the station's air reserves were not infinite) and creates a dangerous pressure bomb if the air were to be spontaneously re-heated.
+
+Additionally, Atmos techs are largely discouraged from using the station's recyclernet, as recycled high-temperature or low-temperature gasses are free to mix with regular temperature gasses, which then get redistributed to the station, heating or cooling the entire station to dangerous levels, which is hilariously hard to undo, given the lack of a station-wide cooling system.
+
+
+## Solution / Core Changes
+### Gas Life Cycle
+Under gas recirculation, gas is to follow a gas life cycle. This cycle is as follows:
+1. Oxygen and Nitrogen flows from gas reserves to a gas mixer.
+2. This gas mixer sends the air to a temperature-controlled mixing chamber, which cools or heats the gasses to standard temperature (293.15 K).
+3. The mixing chamber sends the air to the station's distro.
+4. An air vent pushes the distro air into the atmosphere at a slightly higher pressure than standard atmospheric pressure (above 101.325 kPa, for example this could be set to 115.325 kPa).
+5. The higher pressure air naturally flows to a lower pressure air scrubber (which scrubs ALL gasses until it reaches standard atmospheric pressure, 101.325 kPa).
+6. The air is removed from the atmosphere via the air scrubber and sent to the station's wastenet.
+7. The station's wastenet sends the air to the station's recyclernet, which filters and recyclers the gasses back to the gas reserves.
+8. The cycle repeats.
+
+This allows proper flow-based atmospherics and the proper control of station temperature (and indirectly, pressure)!
+
+### The Gas Mixing Chamber
+The gas mixing chamber is a new system that will have to be enabled at the start of the shift. This system uses a series of radiators exposed to space and a burn chamber to heat or cool the air in the chamber dramatically. To explain it linearly:
+- The chamber will have two radiator loops, one for heating and one for cooling.
+- The air injector (from the gas mixer) is placed so that air has to flow across the radiator loops to reach the passive vent (which leads to distro).
+- An air sensor will be linked to two air alarms, one controlling the hot loop and the other controlling the cold loop.
+- The cold loop air alarm will be set to alarm when the tempreature is above 293.15 K, and the hot loop air alarm will be set to alarm when the temperature is below 293.15 K.
+- The air alarms will send signals to signal valves on their respective radiator loops to control the flow of hot or cold coolant to the radiator loops.
+- Gas will flow across the radiator loops, heating or cooling the gas to standard temperature, based on what is commanded (heating or cooling, based on the current temperature of the gas).
+
+This system allows the cooling or heating of the station's air to standard temperature, which is then sent to the station's distro.
+
+Below is a visual flowchart of the gas mixing chamber, describing a potential solution to the problem:
+
+(This image will be added later when I put the PR up)
+
+### Moving Away from Infinite Gas
+With the proposed system, the station's air reserves no longer have to be infinite.
+The station's air reserves are now a finite resource, which can be recycled and reused.
+Previously, air reserves were infinite and can be replaced at any time.
+This basically invalidated any sense of using the recyclernet to recycle air, as it was easier to just space the gas and replace it with fresh air.
+Now, Atmos will be forced to reduce, reuse, and recycle the station's air.
+
+
+### Required Changes
+Major changes are required to station setups, but the core systems are already present in the game. The following changes are required:
+- An air mixing chamber, with the necessary cooling/heating infrastructure, will have to be mapped to all stations. Some stations do not have an air holding chamber currently.
+- Air scrubbers will have to be changed to scrub all gasses, not just waste gasses. Additionally, air scrubbers will need the PressureBound system added to enable the prevention of drawing gasses from a room past a certain pressure.
+  - This change might be too breaking. An alternative "return vent" could be mapped to the station, which would allow the return of air to the station's recyclernet. This honestly makes more sense, as we're dealing with vent-based gas flow now, not scrubber-based gas management.
+- The ExternalBound of air vents will have to be changed to allow the venting of air at a higher pressure than standard atmospheric pressure, to promote the natural flow of gas.
+- A more complex air alarm may have to be implemented to handle the valve-based control of cooling and heating (perhaps a computer system?).
+
+### Benefits (Arguments for the implementation)
+1. **Proper atmospheric flow.**
+  - This system allows for true, flow-based atmospherics (HVAC) which is a highly complex system, present in real life. This gives Atmos another level of depth and distracts away from sitting in the department waiting for something to happen.
+2. **Station-wide temperature control.**
+  - This system allows for the proper control of station temperature, which is currently a huge issue. Atmos currently has no easy way to modify the station temperature en-masse.
+3. **Emergent gameplay based on the Ideal Gas Law.**
+  - Savvy Atmos techs can take advantage of the Ideal Gas Law to create interesting solutions to station problems. For example, the station's temperature can be increased slightly to increase the effective pressure of the station's air, helping to alleviate a potential gas shortage before more gas is acquired.
+4. **Centralization of station waste gas removal.**
+  - Gas circulation means that all gasses, including waste gasses, are sent to the recyclernet, enabling recycling on a station-wide level, not a room-by-room level.
+5. **Gives Atmos a proper system to manage and keep watch.**
+  - Atmos now has to oversee the station's temperature and gas reserves, which requires constant monitoring and maintaining.
+  - Engineering, in comparison, has the power of overseeing station power, a system which requires constant monitoring and maintaining (singulo gas tank refilling, tesla coil repairs).
+6. **Moves away from infinite gas.**
+  - This system moves away from infinite gas, which is a huge issue in the current atmos system and is a goal in the **Atmos Roadmap**.
+  - As previously mentioned, Atmos techs can space and refill rooms with zero consequence of wasting gas. All problems with bad air can be inherently fixed by just replacing the room's air.
+7. **Encouragement of Frezon gas usage in radiator loops.**
+  - In the future, Frezon can be used as a highly effective working gas for use in radiator loops. Cooling and heating an entire station requires a lot of energy and work to be done. Normal gasses might not have thermal properties good enough for conducting heat fast enough.
+8. **More agency for antagonists.**
+  - Antagonists can now sabotage the station's air supply, which can lead to a station-wide crisis. This can be used to create interesting rounds and scenarios. However, the ease at which this can be accomplished presents greater issues, explained in Drawbacks.
+
+### Drawbacks (Arguments against the implementation)
+1. **Potential for easy and devastating mass station sabotage.**
+  - While it could be argued that this could lead to emergent gameplay and hostage roleplay, it could also lead to 5 minute rounds.
+  - All air returns to a central location, so it is incredibly easy to simply replace all of the air with a harmful gas (carbon dioxide or pure nitrogen).
+  - The entire station's temperature is controlled by two air alarms. It is very easy to sabotage these air alarms and deep fry or freeze the station.
+    - This has some implications for the future Malfunctioning AI gamemode, as they can easily sabotage the station's air supply under Atmos' nose (superheating/supercooling), although this instantly outs the AI and the crew will work to kill the AI posthaste.
+  - This has some counterarguments, though:
+    - Mass station sabotage is prohibited by the rules. Familiarly, mass sabotage like this isn't exactly a huge undertaking, similar to someone snipping wires on a Tesla/Singularity containment.
+    - Because of the flow-based nature of the system, it is possible to detect and fix the sabotage by simply undoing the sabotage. However, half the station could be dead by the time this is done. What are you gonna do? Un-steam half of the station?
+  - This proposal introduces another source of mass station sabotage with a very neutral counterbalance. Right now, changes should be working towards the goal of making mass station sabotage before the 30 minute mark harder.
+
+## Future Systems
+
+In the future, the following systems could be implemented to further enhance the station's atmospherics simulation, to encourage the setup of whole-station HVAC:
+1. **All lifeforms radiate heat into the atmosphere.**
+  - Now that the station's air is temperature-controlled, lifeforms can radiate heat into the atmosphere. This encourages the setup of HVAC, as the station's air will naturally heat up over time, making the station stuffier over time.
+  - To encourage this even further, we could introduce a system where lifeforms experience further discomfort if the station's air is too hot or too cold (rather than simply taking damage).
+2. **All lifeforms sweat (or otherwise emit/exhale water vapor).**
+  - Now that the station's air is recirculating and managed at a central place, lifeforms can sweat, which will increase the humidity of the station's air.
+  - This could warrant the creation of a humidity system, which could be used to further enhance the depth of the atmospherics system.
+  - This could also be used to create a system where lifeforms experience further discomfort if the station's air is too humid or too dry, which could give Atmos another aspect of air to manage.
+  - This system could have parallels with the current presence of water vapor.
+3. **Advanced programmable computers that can preform complex logic.**
+  - Managing temperature and pressure is complex for air alarms. A computer system could be implemented to handle the valve-based control of cooling and heating station air.
+  - This can also enable the precise regulation of pumps to control the specific power of heating and cooling.
+    - This is **exactly** what modern thermostats and air conditioning units do in real life to increase efficiency and reduce energy consumption. Rather than running an AC compressor at full power, the compressor is run at a lower power to maintain a specific temperature.
+  - This system has **huge** potential for emergent gameplay, as savvy Atmos techs can use applied mathematics (Ideal Gas Law, Thermodynamics, Specific Heat Capacity, Energy In/Out) to create complex solutions to station problems.

--- a/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
+++ b/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
@@ -1,8 +1,8 @@
 # Station Air Recirculation (HVAC)
 
-| Designers      | Implemented | GitHub Links |
-|----------------|---|---|
-| ArtisticRoomba | :x: No | TBD |
+| Designers      | Implemented | GitHub Links                                                                                                                  |
+|----------------|-------------|-------------------------------------------------------------------------------------------------------------------------------|
+| ArtisticRoomba | :x: No      | [Atmos Circulation](https://github.com/space-wizards/space-station-14/pull/33380)<br/>Mapping PRs TBD when first PR is merged |
 
 ## Background
 
@@ -70,7 +70,7 @@ This basically invalidated using the recyclernet to recycle air, as it was easie
 
 With the proposed system of recycling gasses, the station no longer has to have an infinite supply of gas.
 
-To promote the usage of the recycling system, gas miners will be tuned to produce much less gas.
+To promote the usage of the recycling system, gas miners will be tuned to produce much less gas, along with other limitations.
 Now, the station's air reserves are a less infinite resource. Atmos will be forced to reduce, reuse, and recycle the station's air.
 
 This does go against the current approved design document for Atmos, which states that the station's air reserves should be finite and gas miners should be phased out.
@@ -86,14 +86,32 @@ However, we still want a small trickle of incoming gas for multiple reasons:
      - I understand this is a repeat of Point 1 but I would like to get this point out on paper because I believe that it is important. Just like the AME (not an extremely perfect analogy), Atmos should have something to fall back on. Maybe make the gas miners take power from the station?
      - Hypothetical: "CE here. An atmos tech accidentally set up the recyclernet wrong and spaced all of the station's gas. Cargo has no money and we are unable to pressurize spaced areas." and shortly thereafter, "The emergency shuttle has been called."
 
+#### Gas Miner Limitations
+Nerfing gas miners by having them produce less gas than previously before is suboptimal. Atmospherics can simply ignore the air mixing chamber, stockpiling pressurized mixed air in a room and instead choosing to dump that to the station's distribution pipenet if things go south.
 
+We can force Atmospherics to setup the air mixing chamber by having mined gasses be too hot for all station life.
 
-### Required Changes
+This forces Atmospherics to temperature-control the gasses using the air mixing chamber, if they ever wish to incorporate these freshly mined gasses into the station's recirculation system.
+
+### Steps for the Implementation
+Implementation of this proposal needs to be followed in a set order:
+1. **Atmospherics system performance needs to be profiled.**
+    - There is a concern that the number of excited groups might impact Atmospherics performance. A technical analysis of the system under gas recirculation needs to be done.
+2. **Stations need to have their atmospherics setups modified.**
+   - All major rooms need to have vents and scrubbers as well as a linked air alarm.
+   - All air vents and air scrubbers need to be positioned in a way so that air can naturally flow from high pressure regions to low pressure regions.
+     - Having air vents and scrubbers right next to each other (which is often the case on most stations) negates the benefits of flow-based atmospherics, even when Monstermos is at play.
+   - Atmospherics needs to have a new air mixing chamber or heat exchanger array mapped, alongside a burn chamber and a radiator array in space.
+3. **The in-game guidebook needs to be updated regarding the new flow-based atmospherics system and how to use it.**
+   - Self-explanatory. Ideally it should be its own section under Engineering → Atmospherics → Atmospherics Systems, and it should explain all aspects of the system, why it exists, and the tips and tricks on how to use it.
+4. **Flow-based atmospherics PR can be merged**
+   - After all of this, the [flow-based atmospherics PR](https://github.com/space-wizards/space-station-14/pull/33380) can be merged. This is further explained in **Required Core System Changes**.
+
+### Required Core System Changes:
 Major changes are required to station setups, but the core systems are already present in the game. The following changes are required:
-- An air mixing chamber, with the necessary cooling/heating infrastructure, will have to be mapped to all stations. Some stations do not have an air holding chamber currently.
 - Air scrubbers will have to be changed to scrub all gasses, not just waste gasses. Additionally, air scrubbers will need the PressureBound system added to enable the prevention of drawing gasses from a room past a certain pressure.
   - This change might be too breaking. An alternative "return vent" could be mapped to the station, which would allow the return of air to the station's recyclernet. This honestly makes more sense, as we're dealing with vent-based gas flow now, not scrubber-based gas management.
-- The ExternalBound of air vents will have to be changed to allow the venting of air at a higher pressure than standard atmospheric pressure, to promote the natural flow of gas.
+- The ExternalBound of air vents will have to be changed to allow the venting of air at higher pressures than standard atmospheric pressure, to promote the natural flow of gas.
 - A more complex air alarm may have to be implemented to handle the valve-based control of cooling and heating (perhaps a computer system?).
 - Tests and observation will have to be done in order to tune gas miner values to ensure that the station's air reserves are not infinite, but still have a small trickle of incoming gas for burn chambers.
 
@@ -158,3 +176,9 @@ In the future, the following systems could be implemented to further enhance the
    - This can also enable the precise regulation of pumps to control the specific power of heating and cooling.
      - This is **exactly** what modern thermostats and air conditioning units do in real life to increase efficiency and reduce energy consumption. Rather than running an AC compressor at full power, the compressor is run at a lower power to maintain a specific temperature.
    - This system has **huge** potential for emergent gameplay, as savvy Atmos techs can use applied mathematics (Ideal Gas Law, Thermodynamics, Specific Heat Capacity, Energy In/Out) to create complex solutions to station problems.
+4. **All machines generate and radiate heat into the atmosphere.**
+   - Currently, machines are magical little devices that take in energy and give you something in return, without generating any heat. With flowmos, we have the basis to change this!
+   - All machines can generate heat internal to themselves, at varying degrees of efficiency (or inefficiency). For example, a lathe can generate 50% of its consumed energy as heat, as a portion of that consumed energy is turned into rotational energy. In contrast, a computer converts almost 100% of its consumed energy to heat.
+   - This heat would be internal to the machine and would have to be radiated away from the machine to the atmosphere. This means that cheesy hyperlathe setups which rely on a spaced room to function would no longer work—they wouldn't have any atmosphere to radiate their internal heat off to, and would quickly melt!
+5. Superconductivity can be re-enabled
+   - Superconductivity is a mechanic that made it so that walls, windows, etc. are not perfect insulators of heat, rather the heat could bleed between the walls, windows, and tiling to make other parts of the station hotter or colder. As of right now, this mechanic is disabled, however, now that atmospherics has real control over the station's temperature; we can look at re-enabling it.

--- a/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
+++ b/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
@@ -62,7 +62,7 @@ This system allows the cooling or heating of the station's air to standard tempe
 
 Below is a visual flowchart of the gas mixing chamber, describing a potential solution to the problem:
 
-(This image will be added later when I put the PR up)
+![image](https://github.com/user-attachments/assets/1f2c42a9-801b-48c6-bded-47537b7bac30)
 
 ### Moving Away from Infinite Gas
 With the proposed system, the station's air reserves no longer have to be infinite.

--- a/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
+++ b/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
@@ -35,85 +35,7 @@ This also leads to more gas entering the room, which drains the station's air re
 Additionally, Atmos techs are largely discouraged from using the station's recyclernet, as recycled high-temperature or low-temperature gasses are free to mix with regular temperature gasses, which then get redistributed to the station, heating or cooling the entire station to dangerous levels, which is hilariously hard to undo, given the lack of a station-wide cooling system.
 
 
-## Solution Preamble
-Testing was actually done using an outdated set of proposed changes, using current systems.
-It demonstrated the realities of a whole-station HVAC system, and the results had their ups and downs.
-However, simple modification to the original proposal shows air circulation is actually **viable** and gives Atmos serious control over the station's temperature and pressure.
-
-The testing environment was as follows:
-- A centralized heating/cooling setup was made similar to the original design document.
-- All air scrubbers were replaced with siphoning vents with an ExternalBound set to 1 ATM.
-- All vents were changed to output gas at 120 kPa.
-- Temperature atmospheric upsets were introduced in multiple areas, like fire anomalies, ice anomalies, to see the effects it had on the air and how the system reacted to it
-
-### Behavior of the system observed during testing
-The tested system demonstrated the following behaviors, in no particular order:
-1. **Recycling gas station-wide puts an astronomically large load on the station's Recyclernet and Distro.**
-   - Because 100 vents were handling +20 kPa of gas, the recyclernet was attempting to recycle and store +2000 kPa of gas. This doesn't even account for has that has been reheated (which makes it even harder to recycle due to pressure increases).
-   - On top of attempting to store +2000 kPa of gas, the distro was attempting to distribute +2000 kPa of gas, which was a huge load on the distro. The distro was never able to achieve standard atmospheric pressure, let alone anything above that.
-     - The system was modified in testing to have as much flow as physically possible, utilizing two gas mixers at max pressure to recycle gas. This was still not enough to handle the requested load.
-2. **The system was able to handle high-temperature upsets.**
-   - As part of testing, a fire anomaly was placed in a room, which over the course of an hour slowly heated the room to 70C (or 343.15 K).
-   - To test the system further, the fire anomaly was critted, which caused a plasmafire. This plasmafire heated the room to around 2000C (or 2273.15 K), and raised the pressure to around 2000-4000 kPa.
-     - The siphoning vent successfully lowered the pressure of the room to it's ExternalBound limit (101.325 kPa), however 1000C+ gas remained in the room, and was not being cooled fast enough from a pathetic 20kPa room temperature flow of gas.
-       - Increasing the gas flow of the air vent to 200 kPa demonstrated fast cooling of the room to near room temperature. Further testing is required to see if this is still the case and is not a one-off. it is important to note that the vent was not really pumping at 200 kPa, as a consequence of Behavior 1 stated above.
-3. **The system was not able to handle extreme low-temperature upsets.**
-    - As part of testing, an ice anomaly was placed in a room, which over the course of an hour slowly cooled the room to 0C (or 273.15 K).
-    - To test the system further, the ice anomaly was critted, releasing frezon into the air, which combined with the present nitrogen and formed nitrous oxide, cooling the air to around -200C (or 73.15 K).
-      - The pressure in the room was lowered considerably, to the point where the vent pressure lockouts engaged. The vents were screwdrivered open to allow room temp gas to flow, which slowly raised the temperature of the room, although not fast enough to make a noticeable difference.
-        - Increasing the gas flow to 200 kPa sped up this process a little bit, but the room was still too cold to be habitable over a long period of time. However, the vent was not really pumping at 200 kPa, as a consequence of Behavior 1 stated above.
-4. **Waste gasses were still present and were not given priority.**
-   - During testing, waste gasses emitted from animals were enough to trigger warning alarms given enough time. The system was recirculating air, but it was simply not doing it fast enough due to Behavior 1.
-5. **The original gas recirculation chamber had a critical design fault.**
-   - The radiators in the gas recirculation chamber were not purged of gas when cooling/heating was no longer commanded.
-     - A passive gate was present to prevent the backflow of heat to the radiator. However, the design did not purge the radiators of residual gas from the system, instead leaving them present to radiate heat into the chamber. This led to 20,000C gas remaining in the radiator, wicking its heat away to the chamber with no way to stop it.
-
-All of these problems are taken into account in the revised proposal. Behavior not listed here was also taken into account.
-
-## Solution and Core Changes
-Unfortunately, as explored above, station-wide gas recirculation is not possible given the current speed of Atmos equipment.
-Increasing the speed to handle the load is not something we want, as this can create absurdly powerful pressure bombs and invalidate a lot of the technical challenges that Atmos techs have to face when building systems "to the max".
-
-However, a solution is still possible, based on a compromise between the current "atmosphere maintenance" system and the proposed "station-wide HVAC" system.
-
-### New Air Scrubber Behavior
-Air scrubbers will now have the PressureBound component, which will prevent the scrubber from drawing gasses from a room past a certain pressure.
-
-This will allow for the proper management of pressure in a room, which is a huge issue in the current atmos system. This also enables pressure-based recirculation.
-
-### New Air Alarm Behavior
-Air alarms will have their operating modes and alarm types expanded, to enable the proper control of cooling and heating systems, and to enable finer control of scrubbers.
-
-Air alarms will get two new modes, "Recirculation" and "Fast Recirculation":
-1. **Recirculation**
-   - Recirculation is enabled when the air alarm senses a "warning" temperature in the room.
-   - Connected air vents will have their pressure bound increased to 150 kPa to push fresh air into the room.
-   - Connected air scrubbers will start scrubbing all gasses.
-2. **Fast Recirculation**
-   - Fast Recirculation is enabled when the air alarm senses a "critical" temperature in the room.
-   - Connected air vents will have their pressure bound increased to 200 kPa (maybe even 500kPa?) to push fresh air into the room.
-   - Connected air scrubbers will start scrubbing all gasses.
-
-The **Filtering (Wide)** also gets its presets changed to scrub all gasses when wide filtering, as a second option to help reduce pressure to normal levels.
-
-Because scrubbers now have the PressureBound system, the room will stay pressurized while gas is being refreshed.
-
-Air alarms will also have their warnings expanded into Pressure, Temperature, and Composition warnings, with their respective output signals.
-This ensures that the Recirculation modes will only enable during a temperature upset, and not a composition upset (where it's simply more efficient to scrub the gas instead of recycle it).
-This also expands the potential of signal-controlled systems that can be made with air alarms.
-
-It is important to note that under this new system, air alarms can experience multiple types of warnings at once.
-Picking the right mode is important, so a mode priority is established.
-
-1. **Fast Recirculation**
-2. **Recirculation**
-4. **Filtering (Wide)**
-5. **Filtering**
-
-This way a gas alarm can "work towards" a solution in the proper "steps".
-This is not invalidating all atmospheric upsets and making everything automatic.
-An air alarm can easily get the operating mode wrong given the situation and an atmospheric technician will correct it on-site and monitor the situation.
-
+## Solution / Core Changes
 ### Gas Life Cycle
 Under gas recirculation, gas is to follow a gas life cycle. This cycle is as follows:
 1. Oxygen and Nitrogen flows from gas reserves to a gas mixer.
@@ -125,7 +47,7 @@ Under gas recirculation, gas is to follow a gas life cycle. This cycle is as fol
 7. The station's wastenet sends the air to the station's recyclernet, which filters and recyclers the gasses back to the gas reserves.
 8. The cycle repeats.
 
-This allows for proper flow-based atmospherics and the proper control of station temperature (and indirectly, pressure)!
+This allows proper flow-based atmospherics and the proper control of station temperature (and indirectly, pressure)!
 
 ### The Gas Mixing Chamber
 The gas mixing chamber is a new system that will have to be enabled at the start of the shift. This system uses a series of radiators exposed to space and a burn chamber to heat or cool the air in the chamber dramatically. To explain it linearly:
@@ -139,8 +61,6 @@ The gas mixing chamber is a new system that will have to be enabled at the start
 This system allows the cooling or heating of the station's air to standard temperature, which is then sent to the station's distro.
 
 Below is a visual flowchart of the gas mixing chamber, describing a potential solution to the problem:
-
-(This image describes the system quite well, but the mixing chamber has major flaws that must be corrected. The underlying principle stays the same.)
 
 ![image](https://github.com/user-attachments/assets/1f2c42a9-801b-48c6-bded-47537b7bac30)
 
@@ -166,13 +86,15 @@ However, we still want a small trickle of incoming gas for multiple reasons:
      - I understand this is a repeat of Point 1 but I would like to get this point out on paper because I believe that it is important. Just like the AME (not an extremely perfect analogy), Atmos should have something to fall back on. Maybe make the gas miners take power from the station?
      - Hypothetical: "CE here. An atmos tech accidentally set up the recyclernet wrong and spaced all of the station's gas. Cargo has no money and we are unable to pressurize spaced areas." and shortly thereafter, "The emergency shuttle has been called."
 
+
+
 ### Required Changes
-Major changes are required to station setups, but the core systems are already present in the game. The following changes are summarized from the proposal above:
+Major changes are required to station setups, but the core systems are already present in the game. The following changes are required:
 - An air mixing chamber, with the necessary cooling/heating infrastructure, will have to be mapped to all stations. Some stations do not have an air holding chamber currently.
 - Air scrubbers will have to be changed to scrub all gasses, not just waste gasses. Additionally, air scrubbers will need the PressureBound system added to enable the prevention of drawing gasses from a room past a certain pressure.
-  - A "return vent" concept was explored in testing, but it was found to be horrible. The PressureBound system is a much more viable solution.
+  - This change might be too breaking. An alternative "return vent" could be mapped to the station, which would allow the return of air to the station's recyclernet. This honestly makes more sense, as we're dealing with vent-based gas flow now, not scrubber-based gas management.
 - The ExternalBound of air vents will have to be changed to allow the venting of air at a higher pressure than standard atmospheric pressure, to promote the natural flow of gas.
-- A more complex air alarm will have to be implemented to handle the valve-based control of cooling and heating, as well as the different modes air scrubbers will operate in.
+- A more complex air alarm may have to be implemented to handle the valve-based control of cooling and heating (perhaps a computer system?).
 - Tests and observation will have to be done in order to tune gas miner values to ensure that the station's air reserves are not infinite, but still have a small trickle of incoming gas for burn chambers.
 
 ### Benefits (Arguments for the implementation)
@@ -236,6 +158,3 @@ In the future, the following systems could be implemented to further enhance the
    - This can also enable the precise regulation of pumps to control the specific power of heating and cooling.
      - This is **exactly** what modern thermostats and air conditioning units do in real life to increase efficiency and reduce energy consumption. Rather than running an AC compressor at full power, the compressor is run at a lower power to maintain a specific temperature.
    - This system has **huge** potential for emergent gameplay, as savvy Atmos techs can use applied mathematics (Ideal Gas Law, Thermodynamics, Specific Heat Capacity, Energy In/Out) to create complex solutions to station problems.
-4. **Negative pressure rooms and filtration/disinfection systems for future disease systems.**
-   - Negative pressure rooms are used in real life to prevent the spread of airborne diseases. This could be implemented in SS14 to prevent the spread of diseases through the station's vent system.
-   - Filtration/disinfection systems could be implemented to further enhance the depth of the atmospherics system. These systems could be used to filter out or disinfect airborne bacteria/viruses from the station's air.

--- a/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
+++ b/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
@@ -14,7 +14,7 @@ This is okay, but this system falls apart when atmospheres experience temperatur
 
 This proposal plans to introduce a pressure-based recirculation system, where temperature controlled air can recirculate to maintain a stable atmosphere. Air will flow from a slightly higher pressure air vent (at 110.325 kPa for example) and move to lower pressure air scrubbers. This gas is then recycled, temperature-controlled, and reintroduced into the atmosphere through Distro.
 
-This proposal also plans to remove Gas Miners, as they are no longer needed with the new system.
+This proposal also plans to move away from infinite gas reserves, to promote the usage of the station's recyclernet. Gas miners will be tuned to produce less gas, to ensure that the station's air reserves are not infinite.
 
 ## The Problem
 
@@ -24,7 +24,7 @@ Currently, air scrubbers **do not** regulate a room's pressure; they simply regu
 2. Cold-based temperature upsets. This includes things like ice anomalies, frezon, and room spacing.
 
 In the event of a heat-based temperature upset, an air scrubber will simply scrub the high-pressure waste gasses and nothing else.
-An atmos tech has to manually drag a station heater and set it up in the area (a machine that some stations don't even have roundstart) to fix the problem.
+An atmos tech has to manually drag a station heater (a machine that some stations don't even have roundstart) and set it up in the area to fix the problem.
 The solution most techs execute is to simply space the gas and refill the room with fresh air. The panic mode on scrubbers is not viable, as it simply operates too slowly compared to RCDing a hole into space.
 **This is not viable given the current atmos roadmap (no infinite gas), as we are actively spacing useful gasses!**
 
@@ -64,12 +64,28 @@ Below is a visual flowchart of the gas mixing chamber, describing a potential so
 
 ![image](https://github.com/user-attachments/assets/1f2c42a9-801b-48c6-bded-47537b7bac30)
 
-### Moving Away from Infinite Gas
-With the proposed system, the station's air reserves no longer have to be infinite.
-The station's air reserves are now a finite resource, which can be recycled and reused.
+### Moving Away from High-Pressure Infinite Gas
 Previously, air reserves were infinite and can be replaced at any time.
-This basically invalidated any sense of using the recyclernet to recycle air, as it was easier to just space the gas and replace it with fresh air.
-Now, Atmos will be forced to reduce, reuse, and recycle the station's air.
+This basically invalidated using the recyclernet to recycle air, as it was easier to just space the gas and replace it with fresh air.
+
+With the proposed system of recycling gasses, the station no longer has to have an infinite supply of gas.
+
+To promote the usage of the recycling system, gas miners will be tuned to produce much less gas.
+Now, the station's air reserves are a less infinite resource. Atmos will be forced to reduce, reuse, and recycle the station's air.
+
+This does go against the current approved design document for Atmos, which states that the station's air reserves should be finite and gas miners should be phased out.
+
+However, we still want a small trickle of incoming gas for multiple reasons:
+1. **To make Atmos independent from Cargo.**
+   - With total reliance on Cargo for gas, Atmos is at the mercy of Cargo's incompetence or malice. A huge spacing could leave Atmos gas-negative and they can do basically nothing about it, as the only way to import gasses is through cargo.
+     - This could be countered by increasing the capacity of air tanks, but we start running to realism issues with container volumes, which was already brought up with similar PRs. Additionally, I think this is a noobtrap/death spiral that should be avoided at all costs.
+2. **To ensure burn chambers are still viable.**
+   - Burn chambers should still be viable for power generation and frezon production. The station should recieve at least some gas, without invalidating the entire point of the reduced output of gas miners.
+3. **To have a safety net to fall back on.**
+   - Atmos is extremely integral to the station and a lack of gas could lead to a station-wide crisis. It is best to simply have a small trickle of gas to ensure that the station does not run out of gas, while promoting gas recycling.
+     - I understand this is a repeat of Point 1 but I would like to get this point out on paper because I believe that it is important. Just like the AME (not an extremely perfect analogy), Atmos should have something to fall back on. Maybe make the gas miners take power from the station?
+     - Hypothetical: "CE here. An atmos tech accidentally set up the recyclernet wrong and spaced all of the station's gas. Cargo has no money and we are unable to pressurize spaced areas." and shortly thereafter, "The emergency shuttle has been called."
+
 
 
 ### Required Changes
@@ -79,6 +95,7 @@ Major changes are required to station setups, but the core systems are already p
   - This change might be too breaking. An alternative "return vent" could be mapped to the station, which would allow the return of air to the station's recyclernet. This honestly makes more sense, as we're dealing with vent-based gas flow now, not scrubber-based gas management.
 - The ExternalBound of air vents will have to be changed to allow the venting of air at a higher pressure than standard atmospheric pressure, to promote the natural flow of gas.
 - A more complex air alarm may have to be implemented to handle the valve-based control of cooling and heating (perhaps a computer system?).
+- Tests and observation will have to be done in order to tune gas miner values to ensure that the station's air reserves are not infinite, but still have a small trickle of incoming gas for burn chambers.
 
 ### Benefits (Arguments for the implementation)
 1. **Proper atmospheric flow.**
@@ -95,11 +112,15 @@ Major changes are required to station setups, but the core systems are already p
 6. **Moves away from infinite gas.**
   - This system moves away from infinite gas, which is a huge issue in the current atmos system and is a goal in the **Atmos Roadmap**.
   - As previously mentioned, Atmos techs can space and refill rooms with zero consequence of wasting gas. All problems with bad air can be inherently fixed by just replacing the room's air.
-7. **Encouragement of Frezon gas usage in radiator loops.**
+7. **Encourages the usage of Frezon gas in radiator loops.**
   - In the future, Frezon can be used as a highly effective working gas for use in radiator loops. Cooling and heating an entire station requires a lot of energy and work to be done. Normal gasses might not have thermal properties good enough for conducting heat fast enough.
 8. **More agency for antagonists.**
   - Antagonists can now sabotage the station's air supply, which can lead to a station-wide crisis. This can be used to create interesting rounds and scenarios. However, the ease at which this can be accomplished presents greater issues, explained in Drawbacks.
-
+9. **Encourages greater care with station atmos setups and adds value to gasses.**
+   - With this change, all gasses are now extremely valuable. Spacing a room's air is no longer a viable solution, as the station's air reserves are no longer infinite. Atmos techs now have to take extra care and ensure that holes are fully patched before filling a room.
+   - This will also lead to Atmos taking great care to ensure that further gas does not escape to space when moving between firelocks. This reinforces the usage of holofans.
+     - Holofans should also see a slight buff to encourage their use and to compensate for the change removing the Firedoor Remote.
+   - This change also encourages Atmos to spend more time ensuring their setups are correct, as a mistake could lead to wasting precious gas or dealing with an expensive-to-fix mess.
 ### Drawbacks (Arguments against the implementation)
 1. **Potential for easy and devastating mass station sabotage.**
   - While it could be argued that this could lead to emergent gameplay and hostage roleplay, it could also lead to 5 minute rounds.
@@ -109,7 +130,13 @@ Major changes are required to station setups, but the core systems are already p
   - This has some counterarguments, though:
     - Mass station sabotage is prohibited by the rules. Familiarly, mass sabotage like this isn't exactly a huge undertaking, similar to someone snipping wires on a Tesla/Singularity containment.
     - Because of the flow-based nature of the system, it is possible to detect and fix the sabotage by simply undoing the sabotage. However, half the station could be dead by the time this is done. What are you gonna do? Un-steam half of the station?
-  - This proposal introduces another source of mass station sabotage with a very neutral counterbalance. Right now, changes should be working towards the goal of making mass station sabotage before the 30 minute mark harder.
+  - This proposal introduces another source of mass station sabotage with a very neutral counterbalance. Right now, changes should be working towards the goal of making mass station sabotage before the 30-minute mark harder.
+2. **Potential performance issues from mass gas flow.**
+  - This system introduces a lot of gas flow by design, which could potentially cause performance issues. The atmospherics system should be properly tested to see if servers can properly handle the load, and optimized if necessary.
+3. **Reduced oxygen available for burn chambers.**
+  - With the tuning of Gas Miners, the station's oxygen supply is now less infinite. This could potentially lead to a lack of oxygen for burn chambers, which could be a problem for the station's power supply. We want to promote the usage of the Thermo-Electric Generator (TEG) as a power source, and this could potentially hamper that.
+  - This could also hamper the production of Frezon, something we still want to promote.
+  - Obviously, I'm just outlining this as a point that this is something that requires tuning. We want to make burn chambers possible for Frezon production and the TEG, whilst preventing the circumvention of the HVAC system. 
 
 ## Future Systems
 

--- a/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
+++ b/src/en/space-station-14/departments/atmos/proposals/station-air-recirculation.md
@@ -121,6 +121,9 @@ Major changes are required to station setups, but the core systems are already p
    - This will also lead to Atmos taking great care to ensure that further gas does not escape to space when moving between firelocks. This reinforces the usage of holofans.
      - Holofans should also see a slight buff to encourage their use and to compensate for the change removing the Firedoor Remote.
    - This change also encourages Atmos to spend more time ensuring their setups are correct, as a mistake could lead to wasting precious gas or dealing with an expensive-to-fix mess.
+10. **Gas mixtures are respected across the station**
+    - Previously, it was very easy for a large gathering of oxygen-breathing species to consume all of the oxygen present in the atmosphere, leading to suffocation. With this change, air will actually be recirculated with a fresh air mixture.
+    - Large courtroom gatherings or a large group of people in medical caused this problem easily.
 ### Drawbacks (Arguments against the implementation)
 1. **Potential for easy and devastating mass station sabotage.**
    - While it could be argued that this could lead to emergent gameplay and hostage roleplay, it could also lead to 5 minute rounds.


### PR DESCRIPTION
An idea I had that enables the recirculation of air throughout the entire station. This is needed for regulating station temperature (something that Atmos seriously lacks) and ties into the Atmos Roadmap.

This also leads to cool emergent gameplay, and it can also lead to the implementation of future systems like humidity and comfort based on temperature.

![stationatmosHVAC drawio (3)](https://github.com/user-attachments/assets/1f2c42a9-801b-48c6-bded-47537b7bac30)
