### PR TITLE
Expand pneumatic valves to have a GUI and inversible

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "spellright.language": [
+        "en_US"
+    ],
+    "spellright.documentTypes": [
+        "markdown",
+        "latex",
+        "plaintext"
+    ]
+}

--- a/src/en/templates/proposal.md
+++ b/src/en/templates/proposal.md
@@ -1,30 +1,17 @@
-# Short, Properly Capitalized Title
-
-Your title should convey the basic jist of your proposed changes. It should be short because the text will be linked in the sidebar.
+# Expand pneumatic valves to have a GUI and inversible
 
 | Designers | Implemented | GitHub Links |
 |---|---|---|
-| Your Names Here | :white_check_mark: Yes or :warning: Partially or :information_source: Open PR or :x: No | PR Links or TBD |
-
-`Designers` should be the names that you use on GitHub and/or Discord. This is optional but strongly recommended, since:
-
-- This acknowledges credit where it is due
-- People who are confused about the written intent can use this information to contact the authors
-
-`Implemented` is the status of the feature.
-
-Github links can include multiple PRs, if relevant.
+| Sinbiosis | :x: No | TBD |
 
 ## Overview
 
-A very short, maybe three sentence summary of what this proposal is about. A high level "overview" or "what this adds".
+Penumatic valves currently have no gui to configure things like threshold or gain. Pneumatic valves also can't be inversed (explained below). This PR seeks to implement both features and to make inversibility a toggle within the GUI.
 
 ## Background
 
-Summarize any information that is needed to contextualize the proposed changes, e.g. the current state of the game.
+Pneumatic valves are like transistors, but for pressure-based systems. The current implementation of these valves is limited and only acts like an NMOS transistor. The "inverse" of this is the PMOS transistor, which for the pneumatic valve, hence forth called the "inverse pneumatic valve", means it allows flow between input and output, but only when the control is 1 atm BELOW whichever port is the higher of the two. I.e. If output > input AND control - 1 atm < output then allow flow.  If output < input AND control - 1 atm < input then allow flow.
 
-Also link any relevant discussions on Discord, GitHub, or HackMD that are relevant to the proposal.
+## Motivation
 
-## The rest?
-
-Is entirely up to you.
+Having a GUI for the pneumatic valve can improve the intutive useability of the valve. Additionally, being able to toggle the inversbility of the pneumatic valve can lead to a lot of FUN™.

--- a/src/en/templates/proposal.md
+++ b/src/en/templates/proposal.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-Penumatic valves currently have no gui to configure things like threshold or gain. Pneumatic valves also can't be inversed (explained below). This PR seeks to implement both features and to make inversibility a toggle within the GUI.
+Pneumatic valves currently have no GUI to configure things like threshold or gain. Pneumatic valves also can't be inversed (explained below). This PR seeks to implement both features and to make inversibility a toggle within the GUI.
 
 ## Background
 
@@ -14,4 +14,4 @@ Pneumatic valves are like transistors, but for pressure-based systems. The curre
 
 ## Motivation
 
-Having a GUI for the pneumatic valve can improve the intutive useability of the valve. Additionally, being able to toggle the inversbility of the pneumatic valve can lead to a lot of FUN™.
+Having a GUI for the pneumatic valve can improve the intuitive usability of the valve. Additionally, being able to toggle the inversbility of the pneumatic valve can lead to a lot of FUN™.


### PR DESCRIPTION
# Expand pneumatic valves to have a GUI and inversible

| Designers | Implemented | GitHub Links |
|---|---|---|
| Sinbiosis | :x: No | TBD |

## Overview

Pneumatic valves currently have no GUI to configure things like threshold or gain. Pneumatic valves also can't be inversed (explained below). This PR seeks to implement both features and to make inversibility a toggle within the GUI.

## Background

Pneumatic valves are like transistors, but for pressure-based systems. The current implementation of these valves is limited and only acts like an NMOS transistor. The "inverse" of this is the PMOS transistor, which for the pneumatic valve, hence forth called the "inverse pneumatic valve", means it allows flow between input and output, but only when the control is 1 atm BELOW whichever port is the higher of the two. I.e. If output > input AND control - 1 atm < output then allow flow.  If output < input AND control - 1 atm < input then allow flow.

## Motivation

Having a GUI for the pneumatic valve can improve the intuitive usability of the valve. Additionally, being able to toggle the inversbility of the pneumatic valve can lead to a lot of FUN™.
