### PR TITLE
Fix whitespace hiding a design doc from the sidebar

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -242,7 +242,7 @@ Space Station 14
 
 		- [Proposals]()
 			- [GenPop Prisoners](en/space-station-14/departments/security/proposals/genpop-prisoners.md)
-                        - [Reduced Metagaming Mechanics](en/space-station-14/departments/security/proposals/reduced-metagaming.md)
+			- [Reduced Metagaming Mechanics](en/space-station-14/departments/security/proposals/reduced-metagaming.md)
 	- [Service](en/space-station-14/departments/service.md)
 		- [PR Guidelines](en/space-station-14/departments/service/guidelines.md)
 


### PR DESCRIPTION
The document Reduced Metagaming Mechanics was hidden due to using spaces instead of tab, which caused the formatting to fail and hid it in the sidebar. This does-a-fixxy.