### PR TITLE
Anomaly Core Extraction

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -236,7 +236,7 @@ Space Station 14
 		- [Proposals]()
 			- [XenoArch Redux (3MOArch)](en/space-station-14/departments/science/proposals/xenoarch-redux.md)
 			- [Xenobio](en/space-station-14/departments/science/proposals/xenobio.md)
-  			- [Anomaly Core Extractor](en/space-station-14/departments/science/proposals/anomalycores.md)
+  			- [Anomaly Core Extractor](en/space-station-14/departments/science/proposals/anomaly-core-extractor.md)
 
 	- [Security](en/space-station-14/departments/security.md)
 		- [PR Guidelines](en/space-station-14/departments/security/guidelines.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -236,6 +236,7 @@ Space Station 14
 		- [Proposals]()
 			- [XenoArch Redux (3MOArch)](en/space-station-14/departments/science/proposals/xenoarch-redux.md)
 			- [Xenobio](en/space-station-14/departments/science/proposals/xenobio.md)
+  			- [Anomaly Core Extractor](en/space-station-14/departments/science/proposals/anomalycores.md)
 
 	- [Security](en/space-station-14/departments/security.md)
 		- [PR Guidelines](en/space-station-14/departments/security/guidelines.md)

--- a/src/en/space-station-14/departments/science/proposals/anomaly-core-extractor.md
+++ b/src/en/space-station-14/departments/science/proposals/anomaly-core-extractor.md
@@ -2,7 +2,7 @@
 
 | Designers | Implemented | GitHub Links |
 |---|---|---|
-| SpaceRox1244 (ricemar on discord) | :x: No | TBD |
+| **SpaceRox1244** and **ayoitslilith** | :x: No | TBD |
 
 ## Overview
 

--- a/src/en/space-station-14/departments/science/proposals/anomaly-core-extractor.md
+++ b/src/en/space-station-14/departments/science/proposals/anomaly-core-extractor.md
@@ -1,0 +1,46 @@
+# Anomaly Core Extractor
+
+| Designers | Implemented | GitHub Links |
+|---|---|---|
+| SpaceRox1244 (ricemar on discord) | :x: No | TBD |
+
+## Overview
+
+Introduce a mechanic of regularly extracting anomaly cores from managed anomalies. Extracted anomaly cores will be used to craft a set of special technology that does not require research-unlocking. These changes will: 
+- give scientists a greater agency over the direction of their research, which they will be able to discuss with the department locals of their field-research site.
+- link exciting rewards to particular research opportunities, which will make assessing the risk of research more engaging for both the scientist and department locals.
+- make many fun technologies available to the round faster, but without compromising what their inclusion lends to round spontaneity and variance.
+- remove certain high tier rewards from competition against each other due to their common resource and unlocking exclusivity, reducing neglect of tech due to a meta.
+- introduces a stronger tech-development responsibility post-research, since currently, unlocking tech cleans science’s hands of involvement in the tech’s existence.
+- bind the production of some tech more closely to science’s consistent operations, since cores are a limited produced resource.
+  
+For immediate clarity, anomalies will still generate research points to support the rest of the research system that involves unlocking technology for infinite crafting.
+
+## The Anomaly Core Extractor (unnamed)
+
+The core extractor is another anchored research device like the APE, but while the APE shoots particles to manage the state of the anomaly, the core extractor shoots a hitscan tether beam to pull a core out of an anomaly. 
+
+The anomaly internally generates a core until it is completely formed and ready to be extracted. Multiple things can progress the formation of a core. Core progress will passively build over time, and anomaly pulses will immediately boost the progress based on the intensity of the pulse. Once the progress is full, a hit from the core extractor tether beam will reset the anomaly’s core progress and deposit an associated core into its bin. 
+
+A scientist will need to collect the cores until satisfied and decide when they want to move on to a new anomaly set in a new location, so that they can develop new tech.
+
+
+## How Will Tech Use Cores?
+
+The set of tech associated with each anomaly type will be available at round start in the protolathe. However, this tech will be printed as either an incomplete prototype or as a device that needs either a certain or any core as fuel. 
+
+A prototype is either totally non-functional or has a bizarre twist on its intended function. From a design perspective, it is not necessary that every tech has a bizarre prototype functionality, it's just a fun thing to implement on the side. 
+
+A core-powered device that consumes its core is something like the gorilla gauntlet. If a researcher wants to displace an anomaly, they will have to manage it long enough in its original location to acquire some cores, and then will have to make the decision to use them to move the research site. 
+
+For clarity regarding this proposal on anomaly cores’ new major purpose, this concept is not at all mutually exclusive with any fun ideas for what else a core can do, like the recently merged ability to microwave meat cores. Infact, these ideas are very positive for this proposal, because it alleviates design weight that might require that every anomaly type produce equally interesting tech.
+
+## Why Are These Changes Positive For Science?
+
+Science is a gameplay loop that is heavy on the progression system, and this means that it has to be designed with a baseline pace of progression in mind, which means it's designed around The Ideal Scenario. The progression system is not scalable for less or more players than the baseline, and as a result science is either incredibly completable or very unproductive. The intention here is to remove some rewards from the progression system and make them available through the gameplay rather than at the end of it.
+
+In addition, science is a very abstracted gameplay loop. Research generates totally anonymous raw research that goes towards unlocking anything permanently, regardless of the activity. While this abstraction is flexible for design, total reliance on it allows a meta to form around which activities are deemed necessary by the community. When any activity does not possess unique opportunities to match its unique risk, players rank them only by harm-prevention, which is far too easy. Medical might refuse cooperation with anomaly research because it is too much of a risk to produce a laundered resource that disappears into a far-away server at R&D which may be spent by someone else outside the communication loop on stepping stones before the needs of the inconvenienced can be discussed and prioritized. In a similar vein, tech rewards redeemed by this common laundered resource are pitted against each other by usefulness, since they all must occupy the same rewards space.
+
+The intention of this proposal is to deliver the potential of research, the cores, directly to the laboring scientist, who is the one present at the site of research, who is the one cooperating with this inconvenienced department, who can learn their needs. Currently, departments often cooperate with science purely out of operating procedure, because it's the thing to do. As players behind their characters, they comprehend that shutting down science is shutting down another player's gameplay, and that consideration is both disappointing and occurs outside the character. By placing the agency with the scientist, who is near the department staff, both are brought closer to the rewards system, and departments can actually ask for things that aren't research-trajectory adjustments because they see tangible in-character opportunities instead of just the ever-present upgrade checklist.
+
+Taking direct advantage of the unpredictability of generated anomalies and their types by associating tech rewards with them feeds into round variance, because now having certain technologies is the result of a capitalized opportunity rather than a decision that was premade by RD at the beginning of the shift based on a current meta.


### PR DESCRIPTION
Add a machine for regularly extracting anomaly cores from anomalies. These cores will now be used to craft a set of round-start available technology that is unique to each anomaly type. 

The intention of this concept is to grant individual scientists more agency over the direction of their individual research, to bring all characters surrounding the anomaly research location closer to the tech rewards system, and to move exciting tech rewards into their own rewards spaces to reduce their relevancy competition.