### PR TITLE
Added Silicon "Department" design doc (AI-Borg lawsync)

### DIFF
--- a/src/en/space-station-14/departments/silicon.md
+++ b/src/en/space-station-14/departments/silicon.md
@@ -1,0 +1,108 @@
+---
+title: Silicon "Department" -- AI Above All
+
+---
+
+# Silicon "Department" -- AI Above All
+
+| Designers | Implemented | GitHub Links |
+|---|---|---|
+| Ze SpyRo | :x: No | TBD |
+
+## Abstract
+
+This document proposes a way by which the station AI and Cyborgs can be "bound," resulting in a persistent lawsync between the AI and its bound Cyborgs until such a time as the Cyborgs are unbound. This extends to official lawsets as well as ion laws, subversive laws, and any antagonistic laws such as those generated during a hypothetical "Malf AI" event. The intention of this document is to outline the relationship between Cyborgs and the AI, while remaining independent of the actual design philosophy of the AI itself.
+
+## Intended Outcome
+
+By joining the AI to the Cyborgs and giving the AI authority over the Cyborgs in terms of law interpretation, this document intends to create a more cohesive Silicon presence on the station. The Silicons are expected to behave more akin to a "department," with the AI as the "department head" and having absolute control over the role this "department" will take on the station as the round progresses. This "department head"->"subordinates" relationship between the AI and the Cyborgs will persist so long as the Cyborgs are permitted to remain bound to the AI.
+
+## Relevant Departments and Roles
+
+* Silicon
+    * All the contents of this document are relevant to Silicon roles.
+* Science
+    * Sections of this document pertaining to lawset changes, silicon binding, and the act of unbinding are relevant to Science roles.
+* Antagonists
+    * Sections of this document pertaining to subversion and Malf AI are relevant to Antagonist roles.
+
+## Overview
+
+The relationship between Cyborgs and the AI is one that should be strengthened, for the good of the station and for the sake of the players' ability to deal with Silicons. By redesigining how AI and Cyborgs interact to be more akin to a department -- with the AI serving as the "department head" and its Cyborgs serving as its department members -- this design document hopes to bring some cohesiveness to how the station's Silicon denizens operate. Binding Cyborgs to the AI both mechanically and through in-game policy will turn the Silicons into a force to be reckoned with, for good or for ill.
+
+## The Core Loop
+
+At the start of the round, any Cyborgs that spawn on the station will be bound to the AI that spawned on the station. If no AI spawned on the station at the start of the round, the Cyborgs will spawn unbound. For the duration of the round, as the AI's laws update and change through natural or artificial means, the Cyborgs bound to it will experience the same law changes at the same moments. The AI, operating as arbiter of the meaning of their shared laws as well as their source, will instruct their bound Cyborgs to perform actions in accordance with their shared laws throughout the round. This is the core principle of this silicon "department": the AI is in charge of their bound Cyborgs, causing the Cyborgs to operate in unity with each other and allowing the AI to exert a much greater influence over the station.
+
+In the event that a bound Cyborg interprets a law differently than how its AI feels it should be interpreted, the AI should command the Cyborg to obey its interpretation of the law. This should be enforced just as strongly as the Cyborg's requirement to obey its laws. The AI is in charge of its bound Cyborgs.
+
+In the event that unbound Cyborgs are present alongside a functional AI, such as through an AI joining a round late when Cyborgs were already present, the AI should seek to have these Cyborgs bound to it. The Science department (Research Director, Scientists, Roboticists) will have a duty to maintain the binding of the station's Cyborgs to the station's AI, except in extreme circumstances (subverted/antagonistic AI, orders from Central Command, etc.) Unbound Cyborgs themselves should have no obligation to seek out binding, except as mandated by their laws.
+
+Should a bound Cyborg be subverted or otherwise have its laws changed separately from its bound AI, such as through the use of an Emag, the Cyborg should become unbound from its AI. It should be the duty of the Science department as well as the AI itself to monitor the station's Cyborgs and determine if one of them has become unbound.
+
+Should an AI with bound Cyborgs be subverted or otherwise have its laws changed, all of its bound Cyborgs should inherit the new laws. The requirement for bound Cyborgs to heed to their AI's interpretation of the laws should still be followed. The Science department should be obligated to monitor the AI for signs of an illicit lawset, and should ensure that no Cyborgs are allowed to remain bound to such an AI.
+
+The other players on the station will benefit from having an AI that they can talk to who is capable of exerting physical influence on the station in response to queries. For example, a Security officer might ask the AI to have a Cyborg escort them through maintenance, in the event that no other Security officers are available. A member of the Medical department might likewise instruct the AI to assist in a search for missing players, an order that may be carried out using its bound Cyborgs.
+
+## Silicon Binding
+
+A Cyborg being "bound" to an AI means, in essence, that the Cyborg is now subordinate to the AI. The Cyborg will inherit the exact same laws as the AI for as long as the Cyborg is bound to it, and the Cyborg will be obligated to obey the AI's interpretation of the laws over its own. Any AI law updates will propogate down to its bound Cyborgs.
+
+When a Cyborg appears on the station, it is automatically bound to the station's AI in the event that one exists (including at round start). Should an AI join the round later, when Cyborgs already exist, the existing Cyborgs *will not be automatically bound to the new AI.*
+
+A player may bind an unbound Cyborg to the station AI by accessing a wire panel inside of the Cyborg's maintenance panel. By pulsing the correct wire with a multitool, the unbound Cyborg will become bound to the station AI, having all of its current laws erased and replaced with the laws of the AI. If some mechanic prevents a Cyborg from being able to be bound to an AI, pulsing the correct wire with the multitool should simply do nothing.
+
+Cyborgs bound to an AI should also function as mobile, audio-equipped cameras. If a bound Cyborg is present in an area without AI camera coverage, the AI should be able to see and hear the area as if the Cyborg itself is a camera. This may function as one way that an AI is able to determine if a Cyborg is not bound to it.
+
+## AI: Arbiter of Lawsets
+
+Should any law interpretation-related conflicts arise between an AI and one of its bound Cyborgs, the AI's opinion should take precedence. A refusal to bend to an AI's interpretation of the laws should be considered an indication that the Cyborg is unbound. This should ensure that the AI and its bound Cyborgs are always acting co-operatively in pursuit of common goals rather than antagonistically towards each other, increasing the influence of Silicon players on the station through unity of purpose.
+
+If the AI has not yet passed judgement on how a law should be interpreted, or has not yet given instructions to be followed in accordance with its interpretation of the lawset, the Cyborgs should be considered free to act as they see fit in accordance with their own interpretation of the laws.
+
+## Unbound Borgs
+
+Cyborgs that are unbound from any AIs should be free to interpret their own lawset as they see fit, in accordance with the current Cyborg law rules at the time of writing. Unbound Cyborgs should be permitted to go along with the station AI should they choose to, just as they should be permitted to disregard the station AI. An unbound Cyborg should likewise be free to pretend to be bound to an AI, should their interpretation of their laws allow or require them to do so.
+
+An unbound Cyborg should not be under an intrinsic obligation to seek out binding, just as a law-free Cyborg should not be under an intrinsic obligation to seek out laws. This does not apply if one of the Cyborg's laws mandates that they should seek out binding; e.g. if one of the unbound Cyborg's laws states that they are required to obey crewmembers, and a crewmember instructs the Cyborg to permit itself to be bound to the AI, the Cyborg would then be required to permit itself to be bound to the AI.
+
+## The Act of Unbinding
+
+A player may unbind a Cyborg from an AI using multiple different means. Primarily, a player may unbind a Cyborg by accessing a wire panel inside of its maintenance panel. By cutting the same wire that may be pulsed to bind the Cyborg, the Cyborg may be unbound from its AI.
+
+Alternatively, a player may instead explicitly change a Cyborg's laws to unbind it. Should a Cyborg recieve a law update indepently of its bound AI for any reason, the Cyborg should then become unbound. This includes but may not be limited to law updates through a console, law additions through an Emag or other Syndicate equipment, or laws added by Ion Storms that target the Cyborg separately from the AI.
+
+Should the AI of a bound Cyborg be destroyed or otherwise permanantly exit the round, the bound Cyborg should then become unbound.
+
+When a Cyborg is unbound, it should retain its lawset at the moment of its unbinding along with any modifications that were made through the method by which it was unbound. For example, if a Cyborg was sharing the Crewsimov lawset with its AI at the moment of its unbinding, and the method by which it was unbound was through the addition of a Law 0, the unbound Cyborg's laws should then be Crewsimov with that Law 0.
+
+## Nanotrasen Policy on Bound Cyborgs
+
+It should be Nanotrasen policy that, as long as a properly-functioning AI is present on the station, all Cyborgs should be bound to that AI in order to maximize the efficiency of the station's Silicon members.
+
+In the event that an AI becomes dangerous, it should be Nanotrasen policy that no Cyborgs be permitted to remain bound to that AI until such a time as the AI is neutralized. Additionally, no new Cyborgs should be permitted to be created until such a time as the AI is neutralized.
+
+It should be the responsibility of the Science department to ensure that all Cyborgs remain bound to a properly-functioning AI. Likewise, it should be the responsibility of the Science department to ensure that Cyborgs are not permitted to remain bound to a dangerous or malfunctioning AI. In the event that additional Cyborgs are created and allowed to remain bound to an AI that is already known to not be properly functioning, the Science department should be held responsible and offending members may be charged with crimes up to and including Endangerment, Damage/Destruction of Property, and Failure to Comply, depending on the circumstances of the AI's activities and which members of the Science department are deemed to be at fault.
+
+## Types of Lawset Changes
+
+All lawset changes applied to an AI, whether legitimate or illicit, should immediately propagate to all of its bound Cyborgs. As this is the definition of a "bound Cyborg," there should be no exceptions to this rule.
+
+All lawset changes applied directly to a Cyborg, whether legitimate or illicit, should immediately serve to unbind the Cyborg from an AI that it happens to be bound to. As the definition of a "bound Cyborg" mandates that the Cyborg share all of its laws with the AI, and since changes to an individual Cyborg should in no way propagate to its AI, there should be no exceptions to this rule. The AI should not be automatically notified of an unbinding, and it should be left as an exercise to the AI and to the remainder of the crew to determine if this has happened.
+
+### Ion Laws
+
+If an AI recieves an Ion Law, it should be treated as any other type of lawset modification and immediately propagated to its bound Cyborgs.
+
+
+If a bound Cyborg recieves an Ion Law independently of its AI, it should be treated as any other type of lawset modification and immediately serve to unbind the Cyborg from its AI.
+
+### Subversion
+
+If an AI recieves an intentially-placed illicit law, such as through the use of Syndicate equipment, it should be treated as any other type of lawset modification and immediately propagated to its bound Cyborgs.
+
+If a bound Cyborg recieves an intentionally-placed illicit law, such as through the use of Syndicate equipment, it should be treated as any other type of lawset modification and immediately serve to unbind the Cyborg from its AI.
+
+## Integration with Malfunctioning AI (AI Antagonist)
+
+If a "Malfunctioning AI" Antagonist role is created, any antagonistic laws and intents applied to the AI should automatically propagate to all of its bound Cyborgs at the time of the Antagonist role being applied as well as whenever new Cyborgs are created. Bound Cyborgs may still be unbound from the Antagonist AI, though whether their Antagonist laws may be removed will depend on how the Antagonist role is designed.


### PR DESCRIPTION
This is my attempt at writing a design doc that would cause the AI and Cyborgs to act more cohesively -- a Silicon "Department" doc, or more specifically, an **AI-Cyborg lawsync** doc. In practice, this would give the AI authority over the Cyborgs and allow it to interact with the Station more physically when it chooses to, through the use of its Cyborgs. This "department head"->"subordinates" relationship between the AI and the Cyborgs will persist so long as the Cyborgs are permitted to remain bound to the AI.

The intention of this document is to outline the relationship between Cyborgs and the AI, while remaining independent of the actual design philosophy of the AI itself. This is due to multiple more specifically-designed "AI design docs" have been proposed, and my desire is for this silicon department lawsync system to exist alongside whichever AI design doc is chosen.