### PR TITLE
Clarify licensing format for project-original sprites

### DIFF
--- a/src/en/space-station-14/art.md
+++ b/src/en/space-station-14/art.md
@@ -195,7 +195,7 @@ Either respriting to a smaller size or using technical elements that preserve th
 
 ### Licensing
 * the `meta.json` file requires the author to supply both a license and a copyright.
-The copyright is simply the provenance of the art within the file, specifying the specific codebase and commit that the asset was taken from.
+The copyright is simply the provenance of the art within the file, specifying the specific codebase and commit that the asset was taken from. For new assets originating in this codebase, the PR where they are introduced should be listed (to make it easier for other projects to find the source, for their own attribution reference).
 The license is a specific copyright license used for assets.
 
 


### PR DESCRIPTION
This came up in conversation on discord, and it turned out that we don't have this specified
https://discord.com/channels/310555209753690112/1294733932046319646/1318206029325926494