### PR TITLE
Improve design doc template

### DIFF
--- a/src/en/templates/proposal.md
+++ b/src/en/templates/proposal.md
@@ -25,6 +25,34 @@ Summarize any information that is needed to contextualize the proposed changes, 
 
 Also link any relevant discussions on Discord, GitHub, or HackMD that are relevant to the proposal.
 
-## The rest?
+## Features to be added
 
-Is entirely up to you.
+Give a description of what game mechanics you would like to add or change. This should be a general overview, with enough details on critical design points that someone can directly implement the feature from this design document. Exact numbers for game balance however are not necessary, as these can be adjusted later either during development or after it has been implemented, but mention *what* will have to be balanced and what needs to be considered when doing so.
+
+## Game Design Rationale
+
+Consider addressing:
+- How does the feature align with our [Core Design Principles](../space-station-14/core-design/design-principles.md) and game philosphy?
+- What makes this feature enjoyable or rewarding for players?
+- Does it introduce meaningful choices, risk vs. reward, or new strategies?
+- How does it enhance player cooperation, competition, or emergent gameplay?
+- If the feature is a new antagonist, how does it fit into the corresponding [design pillars](../space-station-14/round-flow/antagonists.md)?
+
+## Roundflow & Player interaction
+
+Consider addressing:
+- At what point in the round does the feature come into play? Does it happen every round? How does it affect the round pace?
+- How do you wish for players to interact with your feature and how should they not interact with it? How is this mechanically enforced?
+- Which department will interact with the feature? How does the feature fit into the [design document](../space-station-14/departments.md) for that department?
+
+## Administrative & Server Rule Impact (if applicable)
+
+- Does this feature introduce any new rule enforcement challenges or additional workload for admins?
+- Could this feature increase the likelihood of griefing, rule-breaking, or player disputes?
+- How are the rules enforced mechanically by way the feature will be implemented?
+
+# Technical Considerations
+
+- Are there any anticipated performance impacts?
+- Does the feature require new systems, UI elements, or refactors of existing ones?
+- For required UI elements, give a short description or a mockup of how they should look like (for example a radial menu, actions & alerts, navmaps, or other window types)


### PR DESCRIPTION
A lot of new or existing design docs are not up to standard, often they simply end up as a sort of shopping list of new features rather than addressing the actual design rationale or technical details behind them.
This new template is supposed to give authors suggestions what to discuss in their doc and provide a rough format for doing so.
Feedback is welcome!