### PR TITLE
"Move Circuit Imprinters to Engineering" Proposal

### DIFF
--- a/src/en/space-station-14/departments/engineering/proposals/circuitimprinter.md
+++ b/src/en/space-station-14/departments/engineering/proposals/circuitimprinter.md
@@ -1,0 +1,49 @@
+# Move Circuit Imprinters to Engineering
+
+| Designers | Implemented | GitHub Links |
+|---|---|---|
+| Compilatron | :x: No | TBD |
+
+## Overview
+
+This proposal is for the circuit imprinter to be moved to engineering on all maps.
+
+## Background
+
+Recently, the protolathe was removed from engineering, to be a science exclusive - in order to foster inter-department interaction. This makes sense, but also means that science is now the sole arbitrair of any researched items.
+
+As it currently stands, engineers have the responsibility of setting up power and atmospherics - usually a 5-10 minute venture. From there, they can at most help with construction works and meteor damage repair. This leaves very little opportunity for engineers to have a meaningful round impact beyond repairs. In other words, "nobody notices a good engineering department, but always notices a bad one".
+
+Engineering is already responsible for the hull, power and air - and it should make sense that machine construction should fall under that umbrella. They're already the most capable department for construction, but rarely have a reason to do so without aid from other departments. This often means that departments will handle construction works themselves, instead of enlisting an engineer to do so.
+
+## Moving the circuit imprinter
+
+Maps should be modified to remove the circuit imprinter from science, and place it in engineering. If engineering had a protolathe, it should be removed and replaced with the imprinter.
+
+## Benifits of moving the circuit imprinter
+
+### Encourages engineers to do construction work
+
+Science rarely do any external construction work, both being focused on their own department and lacking the tools to do so. Engineers have much more reason to do construction works and the tools to do so.
+
+### Encourages interdepartmental interactions
+
+Giving engineering the means to install machinery in departments would encourage other departments to enlist their aid in works. This means engineers can spend extended periods of time inside other departments (whereas they would normally only be doing so if it was uninhabitable), which can provide opportunities for antagonists to collaborate or strike.
+
+### Allows more self expression
+
+Engineers rarely get much opportunity for self expression, lacking much reason for doing construction works usually. Giving them the ability to produce machinery would allow them to spend their time building areas for self expression, in much the same way a tider outfits the maint bar.
+
+### Encourages cargo to distribute materials more evenly
+
+Cargo only ever needs to deliver materials to science - but by having two high-material consumption departments, it encourages cargo to work with both to properly distribute the materials they need.
+
+## Downsides of moving the circuit imprinter
+
+### Makes science reliant on engineering
+
+This proposal would make science reliant on engineering for machine upgrades, but this could also promote the departments to work together more closely.
+
+### Allows engineering to become more self sufficient
+
+Although already possible by raiding the tech vault, engineers can build a protolathe for themselves to use. If this is a critical issue, these devices can be removed from the circuit imprinter or otherwise rebalanced.


### PR DESCRIPTION
Proposal doc for moving the circuit imprinter from science to engineering.

Gives engineering something to do - thus extremely controversial.