### PR TITLE
Design Document: Security Department

### DIFF
--- a/src/en/space-station-14/departments/security.md
+++ b/src/en/space-station-14/departments/security.md
@@ -1,43 +1,38 @@
-```admonish warning "Attention: Placeholder!"
-This section is a placeholder, pending a design-doc being created by the related work-group
-```
-
-# Security
-SpaceCops... Bad boys, bad boys, whatcha gonna do when they come for you...
+# Security Department Design Document
 
 ## Concept
-> A high-level conceptual overview of what this department does. This is generally 1-2 paragraphs and should reflect a high level view of what this department brings to the player and the game. 
+The Security department is the primary counter-weight against the many chaotic PvP and PvE events that occur on the station, allowing the other departments to focus on their gameplay without (too much) interuption. Combat and "busting bad guys" should be the main draw to play Security, though not to the extent they oppress other roles from doing their goals. They also assist with player-enforced behaviors via Space Law, acting as an in-game way to ensure other players don't detract from the experience for each other.
 
-## Player Story
-> A short (1-2 paragraph) story from the perspective of someone playing a role in this department. This is effectively a story of the ideal experience of a player interacting with these mechanics/systems. 
+## Intended Experience
+- Rip-roaring combat; shooting guns and taking down bad guys.
+- A sense of empowerment; you keep the station safe, and have the tools to do so.
+- Processing and law; codes to follow, to ensure fair treatment.
+- Friction with crew; other crew should be treated fairly, or there will be consequences.
+- Good for intermediate to experienced players.
 
-## Design Pillars
-> A group of simple high-level ideas that embody this department. These are usually expressed with singluar words or short phrases, but may also include a *short* one sentence explaination. Game pillars are what makes the *identity* of the department. 
+## Responsibilities
+- Security protects the station & crew from hostilities, having the best equipment to do so.
+- Security contextually enforces Space Law, an in-game law system players agree on when playing the game (as well as the consequences for breaking it).
+- Security ensures secure storage of strong combat equipment and weapons.
 
-> Pillars are there to act as guides when creating new mechanics or interactions, they serve as the measuring posts to make sure that what you are trying to do will fit in the department gameplay. 
+## Desired Gameplay
+- Being called upon to deal with station threats.
+  - Other crew should be able to rely on Security for assistance against threats that disrupt their role's purpose; whether that be low-stakes disputes between players or round-ending threats. Security doesn't always need to be able to succeed in dealing with the threats, but should be considered a viable option.
+  - Security should also have options to discover threats on their own. These options should be subvertible and balanced to not be oppressive for antags, yet be reliable enough that a Security player feels it's useful. This kind of proactive work should be ideal for downtime between more reactive threats, when there's a lull in the action. 
+- Risk of friction when performing work.
+  - Security should need to rely on other departments and players to perform well; failing to have good relationships may cause other players to deny access, obscure information and/or assist antagonists. This reliance may temporarily distract other players from their role's purpose, causing a base amount of friction that must be overcome.
 
-> To acheive this you want pillars that are concrete enough to get your concept across but broad enough that there is some room of interpretation and discussion.
+- Higher than normal crew combat capabilities, but needing to use resources/teamwork to effectively combat antagonists.
+  - As the station's protectors Security should be stronger than the average crewmember, with the possibility to become even stronger by utilizing resources or tools provided by other departments. A single Security role should still baseline be less powerful than a primary antagonist, with teamwork and skillful play bridging the gap.
+- Fairly enforcing Space Law, in favor of what's best for the round and player.
+  - Security should only enforce Space Law to the extent that it makes sense in context; being the enforcers, they are also expected to follow it. 
 
-### Pillar_1:
- > Breif Pillar Description
-
- ### Pillar_2:
- > Breif Pillar Description
-
-## Objectives
-> What is this department's objective when it comes to the round? Do they have a unique failure condition? If so, what is it? How does this department's objectives interact with the rest of the station?
-
-## Progression
-> How does the *gameplay* of this department change over the course of a round? Are there unlocks? Are players collecting/spending resources? Is this progression tied/related to other departments? If so how?
-
-## Flow
-> How does the *experience* of the player change over the course of a round? Are players constantly running around putting out fires or are there breaks in the action? Do players need to wait on other departments as pre-requisites for their own gameplay, or is this department fairly self-sufficent?
-
-## Mechanics
-> What major mechanics does this department use and how are they connected to this department.
-
-### Mechanic_Placeholder1
-> Each mechanic should have its own subheading and should contain a *short high-level* overview of the mechanic and how it is used by this department. Each mechanic should also link their associated design document as the subheading.
-
-### Mechanic_Placeholder2 (Not Implemented Yet)
-> Mechanics that are unimplemented should be marked with (Not Implmented Yet) and should link the associated design proposal if it exists.
+## Undesired Gameplay
+- Speedrunning to redtext antagonists to make each round a greenshift.
+  - While Security will be engaging with antags frequently and part of that work involves pre-emptively detecting antags, it becomes overall detrimental to the round if Security "defeats" antags too early. It becomes anti-climactic, unenjoyable for the antag, and detracts from the level of chaos in the round.
+- Militaristic behaviors and design.
+  - Security should lean more towards the "mall cop" archetype rather than being a military force. That doesn't mean they won't have access to military-grade equipment such as assault rifles, armor or bomb diffusal tools, they are in a futuristic sci-fi setting after all, just that the overall design shouldn't impose military levels of structure and rigor. 
+- Becoming a police state/unfairly enforcing space law. 
+  - Security has the tools to very forcefully oppress other departments and players; sometimes this force may be necessary to deal with unruly players or antagonists, but exercising it wantonly to the detriment of other players can cause great unenjoyment and should not be encouraged.
+- Always opting for lethal means.
+  - Lethality when dealing with threats is important as it can provide an innate definitive end to the threat, however the impact injuries and death can have on other players means Security should not be encouraged to always go for a lethal option.


### PR DESCRIPTION
This PR includes a rewrite of the Security Department design document, following the template from #397. It's originally based on a proposal by @keronshb.

This is a directional design document, meaning the goal is to define boundaries and goals for the game area (in this case, the Security department). It is not aiming to provide specific mechanics or implementations, and instead act as a guidance for future PRs in this area, both for contributors when making PRs and Maintainers when evaluating them.

Should this PR be merged it will act as a reference point for future departmental and game area design docs, as an example for how a directional documents should look. 