### PR TITLE
add implementation plan requirement to design docs

### DIFF
--- a/src/en/templates/proposal.md
+++ b/src/en/templates/proposal.md
@@ -60,6 +60,6 @@ Consider addressing:
 
 # Technical Considerations
 
+- Does the feature require new systems, UI elements, or refactors of existing ones? Give a short technical outline on how they will be implemented.
 - Are there any anticipated performance impacts?
-- Does the feature require new systems, UI elements, or refactors of existing ones?
 - For required UI elements, give a short description or a mockup of how they should look like (for example a radial menu, actions & alerts, navmaps, or other window types)

--- a/src/en/templates/proposal.md
+++ b/src/en/templates/proposal.md
@@ -3,7 +3,7 @@
 Your title should convey the basic jist of your proposed changes. It should be short because the text will be linked in the sidebar.
 
 | Designers | Coders | Implemented | GitHub Links |
-|---|---|---|
+|---|---|---|---|
 | Your Names Here | :white_check_mark: Yes or :warning: Partially or :information_source: Open PR or :x: No | PR Links or TBD |
 
 `Designers` should be the names that you, the author of this document, use on GitHub and/or Discord. This is optional but strongly recommended, since:

--- a/src/en/templates/proposal.md
+++ b/src/en/templates/proposal.md
@@ -4,7 +4,7 @@ Your title should convey the basic jist of your proposed changes. It should be s
 
 | Designers | Coders | Implemented | GitHub Links |
 |---|---|---|---|
-| Your Names Here | :white_check_mark: Yes or :warning: Partially or :information_source: Open PR or :x: No | PR Links or TBD |
+| your names here |coder names here| :white_check_mark: Yes or :warning: Partially or :information_source: Open PR or :x: No | PR Links or TBD |
 
 `Designers` should be the names that you, the author of this document, use on GitHub and/or Discord. This is optional but strongly recommended, since:
 

--- a/src/en/templates/proposal.md
+++ b/src/en/templates/proposal.md
@@ -4,9 +4,9 @@ Your title should convey the basic jist of your proposed changes. It should be s
 
 | Designers | Coders | Implemented | GitHub Links |
 |---|---|---|---|
-| your names here |coder names here| :white_check_mark: Yes or :warning: Partially or :information_source: Open PR or :x: No | PR Links or TBD |
+| your names here | coder names here | :white_check_mark: Yes or :warning: Partially or :information_source: Open PR or :x: No | PR Links or TBD |
 
-`Designers` should be the names that you, the author of this document, use on GitHub and/or Discord. This is optional but strongly recommended, since:
+`Designers` should be the names that you, the authors of this document, use on GitHub and/or Discord. This is optional but strongly recommended, since:
 
 - This acknowledges credit where it is due
 - People who are confused about the written intent can use this information to contact the authors

--- a/src/en/templates/proposal.md
+++ b/src/en/templates/proposal.md
@@ -2,14 +2,20 @@
 
 Your title should convey the basic jist of your proposed changes. It should be short because the text will be linked in the sidebar.
 
-| Designers | Implemented | GitHub Links |
+| Designers | Coders | Implemented | GitHub Links |
 |---|---|---|
 | Your Names Here | :white_check_mark: Yes or :warning: Partially or :information_source: Open PR or :x: No | PR Links or TBD |
 
-`Designers` should be the names that you use on GitHub and/or Discord. This is optional but strongly recommended, since:
+`Designers` should be the names that you, the author of this document, use on GitHub and/or Discord. This is optional but strongly recommended, since:
 
 - This acknowledges credit where it is due
 - People who are confused about the written intent can use this information to contact the authors
+
+`Coders` should be the names of the contributors who plan on implementing this feature. To get a design doc approved you will need either
+- have the technical knowledge to be able to implement the proposed feature yourself.
+- have someone else who agreed to do this for you.
+- already have an existing implementation elsewhere that just needs to be ported.
+In either case you will have to write a technical outline on how you plan to implement this feature to show that it is technically sound.
 
 `Implemented` is the status of the feature.
 

--- a/src/en/templates/proposal.md
+++ b/src/en/templates/proposal.md
@@ -16,7 +16,7 @@ Your title should convey the basic jist of your proposed changes. It should be s
 - have someone else who agreed to do this for you.
 - already have an existing implementation elsewhere that just needs to be ported.
 
-In either case you will have to write a technical outline on how you plan to implement this feature to show that it is technically sound.
+In either case you will have to write an outline on how you plan to implement this feature in the **Technical Considerations** section to show that is technically sound and feasible.
 
 `Implemented` is the status of the feature.
 

--- a/src/en/templates/proposal.md
+++ b/src/en/templates/proposal.md
@@ -15,6 +15,7 @@ Your title should convey the basic jist of your proposed changes. It should be s
 - have the technical knowledge to be able to implement the proposed feature yourself.
 - have someone else who agreed to do this for you.
 - already have an existing implementation elsewhere that just needs to be ported.
+
 In either case you will have to write a technical outline on how you plan to implement this feature to show that it is technically sound.
 
 `Implemented` is the status of the feature.


### PR DESCRIPTION
Discussed internally in https://forum.spacestation14.com/t/require-implementation-plan-in-design-doc-proposals/18637
To summarize, a lot of design docs lack critical details about how the technical implementation is planned, and some proposed features were literally impossible in our game engine. Other docs had been accepted a long time ago, but have never been implemented.
Both of these may happen if the author of the doc does not have the required coding knowledge themselves. To solve this we will require authors of new design docs to confirm that they plan on implementing the proposed feature either themselves, or have someone else do it for them.
This helps maintainers to focus on design docs that actually have a chance to be implemented in the foreseeable future.
Existing docs will not be affected.

