### PR TITLE
Revised PR Review Procedure

### DIFF
--- a/src/en/wizden-staff/maintainer/review-procedure.md
+++ b/src/en/wizden-staff/maintainer/review-procedure.md
@@ -115,7 +115,7 @@ They can be used both when there are disagreements regarding a PR and when a mai
 PRs actively undergoing a maintainer discussion should not be merged.
 
 To begin the discussion process, add the `S: Undergoing Maintainer Discussion` tag.
-This should automatically create a post in the `#maint-reviews` discord channel with the PR's name, number, link, and appropriate tags.
+The maintainer should then create a post in the `#maint-reviews` discord channel with the PR's name, number, link, and appropriate tags.
 
 Discussion can then proceed with maintainers and admins giving opinions and coming to a conclusion or compromise.
 Once a conclusion is reached or regular discussion ceases, one of the following must occur:

--- a/src/en/wizden-staff/maintainer/review-procedure.md
+++ b/src/en/wizden-staff/maintainer/review-procedure.md
@@ -1,54 +1,191 @@
 # PR Review Procedure
 
-This documents lists the Maintainer procedure for reviewing and merging PRs to the [Space Station 14 repository](https://github.com/space-wizards/space-station-14). 
+This documents lists the Maintainer procedure for reviewing and merging PRs to the [Space Station 14 repository](https://github.com/space-wizards/space-station-14) `master` branch. 
+Hotfixes intended to be merged directly to the `stable` branch must follow additional restrictions specified in the [Hotfix Procedure](hotfix-procedure.md).
 
-## Requirements
-- All PRs **should** adhere to the [code conventions](../../general-development/codebase-info/conventions.md), but this is *not* a hard requirement since some specific usecases may require straying from convention for readability.
-- PRs **should** be triaged, as per the [triage procedure](triage-procedure.md) guidelines. If a PR is not triaged, this can be done at the same time as the PR is initially considered for review.
-- PRs affecting gameplay **should** reference a design doc/proposal if one exists. For smaller changes, or where design documentation does not exist yet, the design may instead be outlined in the PR description. All gameplay PRs must not conflict with the [core design principles](../../space-station-14/core-design/design-principles.md) and should ideally reference how they fit into it. The responsibility to include this is on the PR author.
-- **2 Maintainers are required to review/sign off on merging or closing a PR**. *This requirement may be waived with written permission from a PM when the situation warrants it (either on Github, Discord or the SS14 forums).*
-  - For merging, this takes the form of 2 "Approval" checkmarks from Maintainers on the PR (visible in the PR's comments or under "Reviewers" in the Github sidebar). This Approval can also be given in written form during discussions on other platforms such as Discord or the SS14 forums, as long as it is also stated by another Maintainer in a comment under the PR. If the PR author is a Maintainer, this automatically counts as the PR having 1 Approval. Github will automatically assign a PR with 1 Maintainer approval the `S: Approved` label. *An "Approval" checkmark implies that you have reviewed and approved the PR's contents (code, art, mapping change etc.). If you approve of the PR conceptually without reviewing it this can be written in a PR comment, but does not count as an Approval. The label "S: Conceptual Approval" is reserved for Maintainer Discussions and may not be used in this instance.*
-    - Any PR that carries the `Changes: Sprites` label needs to be approved by an Art Lead. This takes the form of the `S: Art Approval` label or an approval via Discord or Forums. Art Leads are responsible for ensuring the `S: Art Approval` label is applied to PRs when they approve of them.
-  - For closing, this takes the form of 2 Maintainers expressing an opinion to close the PR, or a reluctance to implement the PR, in the PR's comments. This "Disapproval" can also be given in written form during discussions on other platforms such as Discord or the SS14 forums, as long as it is also stated by another Maintainer in a comment under the PR.
-  - In the case where there's dissent among maintainers, e.g. 2 Approvals and 1 Disapproval, a Maintainer Discussion should be held as described under the Policy section.
-  - You do not need to be one of the two Maintainers who have given Approval/Disapproval to merge/close the PR. Ideally a PR should be processed once it meets the requirements to be merged/closed, but if that does not happen for some reason, any other Maintainer is free to do it (even if that Maintainer is the PR author).
-- PRs that have more than 3 weeks of inactivity waiting on something from the PR author should be considered "stale" and labeled as such with the `S: Stale` label, unless another reason explains the inactivity (e.g. freeze or author has informed about a longer break). You may use any means to contact the author of the PR, but at the minimum you should leave a comment on the PR and give at least 1 week to respond before closing a stale PR. A PR that is waiting on an action from Maintainers (e.g. a code review or discussion resolution) is not eligible to be marked as stale.
-- PRs that change public APIs, move code into another namespace, change a prototype ID / prototype definition in C# etc. should contain a "breaking changes" section. This section should contain a summary of the changes and how to apply them. Upon merging the PR it is the maintainers task to post the breaking changes section (Not just the PR link!) into `#codebase-changes`. The message format should first include a link to the PR, then the "breaking changes" section copied from the PR and lastly a ping for `@contrib-notifications.`. While not necessary, checking the message for spelling errors and correcting them is preferred.
+Any portion of this procedure may be waived and/or modified with permission from a Project Manager or Wizard.
+
+Failure to follow this procedure may result in disciplinary action. Tread carefully, maintainer.
+
+## PR Requirements
+All PRs must adhere to the [code conventions](../../general-development/codebase-info/conventions.md).
+
+All PRs must be triaged, as per the [triage procedure](triage-procedure.md) guidelines. 
+If a PR is not triaged, this should be done at the same time as the PR is initially considered for review.
+
+All PRs must not conflict with [core design principles](../../space-station-14/core-design/design-principles.md). 
+Additionally, the PR author should describe how the changes they made fit into the game.
+Sufficiently large PRs may also warrant a **Design Doc** detailing the broader scope and purpose of their changes.
+
+All PRs that include **breaking changes** (*e.g. modifying public APIs, moving code into another namespace, changing a prototype ID, etc.*) should contain a "breaking changes" section.
+This consists of a summary of the changes as well as how to apply them.
+After the PR is merged, the maintainer should format a message containing the PR link, the entirety of the "breaking changes" section, and a ping for `@contrib-notification` and post it into the `#codebase-changes` channel of the Discord.
+
+All PRs must complete fill out the Github PR Template to a satisfactory level.
+This includes filling out all applicable sections and attaching media when necessary.
+
+## Decision Policy
+2 Maintainers are required to sign off on decisions about a PR.
+One of the maintainers is allowed to be an author of the PR, but the other should be uninvolved.
+
+To merge a PR, **all** the following conditions must be met:
+- The PR must receive 2 approvals for both **Code** and **Design**, given in the form of an approval checkmark on the PR's Github page.
+A checkmark is assumed to indicate approval for both code and design, unless stated otherwise by the approver.
+A PR created by a maintainer is assumed to have their implicit approval.
+
+
+- All outstanding maintainer change requests must be resolved.
+If the maintainer who left the request wants, they can choose to forgo requiring the changes.
+In this case, when the PR is merged, a Github issue should be created to indicate the changes that need to be made.
+
+
+- If the PR has the `Changes: Sprites` label, it must additionally be approved by at least one **Art Lead** through the addition of the `S: Art Approval` tag.
+
+
+To close a PR, at **least one** of the following conditions must be met:
+- At least 2 maintainers must express wanting to close the PR or an unwillingness to merge it. 
+This can be expressed either on the PR itself, or privately.
+
+
+- The PR contains content which violates Wizard Den's rules and/or code of conduct.
+
+
+- The PR author has been banned from the Wizard's Den Github and/or Discord or is otherwise unable to be communicated with.
+
+
+- The PR is **Stale** (see section "Expedited Decision-Making").
+
+
+- The PR has been superseded by a different PR and thus no longer needs to be merged.
+
+If a PR is closed, the maintainer must leave a message indicating the reason for its closure.
+This should be a formal message that includes all relevant information.
+
+If there is disagreement between two maintainers about whether a PR should be merged or closed, a discussion should be held as described in the "Discussion Policy" section.
 
 ### Exemptions:
-- PMs and Wizards may waive any PR Review Procedure requirements if deemed necessary for the health of the project. When doing so, it should be done via written permission with an explanation (either on Github, Discord or the SS14 forums). Note that this exemption is not the default for actions taken by the relevant roles, and should be explicitly invoked when used.
-- If a triaged PR carries the `T: Bugfix`, `T: Cleanup`, `T: Performance` or `T: Refactor` labels, *and* does not carry the `T: New Feature` or `T: Balance Change` labels, then the PR is exempt from the "2 Maintainer" requirements for merging/closing and can be processed by a single maintainer. 
-  - If a maintainer is the author of a PR, this exemption does not apply (i.e no self-merges).
-  - This exemption is intended for smaller PRs, *or* PRs where the reviewing maintainer has extensive knowledge about the affected code.
-  - It is expected that the reviewing maintainer uses their judgement for whether a PR should make use of this exemption, or if an additional review from another maintainer is more suitable.
-- Maintainer Maptainers (i.e. Maintainers with additional responsibilities regarding Mapping) may ignore the "2 Maintainer" requirements for merging/closing any PRs involve mapping changes. This means a only single Maintainer Maptainer is needed to approve and merge mapping PRs, and also are able to self-merge mapping PRs.
-  - Map tooling PRs are not included in this exemption.
-  - Map hotfix PRs are not included in this exemption and must still follow normal hotfix procedure.
-- Rule change PRs and server config change PRs submitted by (or with written approval from) a Head Game Admin do not need to adhere to the PR Review Procedure.
 
-## Policy
-- When starting a new review for a PR that has not yet been assigned to a Maintainer, you are **required** to Assign yourself to the PR. This can be done under "Assignees" in the Github sidebar. This let others know that you will be "owning" the PR. If you decide to stop owning the PR, un-assign yourself so that others may take over the PR. By owning a PR you are taking responsibility for keeping track of the PR's progress, ensuring code quality and keeping the PR author informed of what is the status of the review process. If you are the PR author yourself, you may not also be the PR owner. Anyone may review an owned PR. *If changes are Approved/Disapproved by the PR owner any Maintainer may merge the PR if they also Approve/Disapprove the changes, provided there is no other Maintainer dissent.*
+```admonish info "Use Your Head"
+The following are situations in which the typical decision policy can be modified or opted out of.
+If you do not feel confident, feel free to follow the normal process.
+```
 
-- If you think a PR warrants further discussion with maintainers, or there is dissent regarding merging/closing, you may **optionally** start a Maintainer Discussion. **This is not a requirement**, but is recommended when you aren't sure about something. If you choose to do this, you are **required** to tag the PR with the "S: Under Maintainer Discussion" label, which should automatically cause a thread with the PR's name, PR number, Github link and appropriate tags/pings to be created on Discord in the #maint-review channel. If this does not happen automatically (e.g. the Discord bot is down or otherwise unavailable), you should create the thread manually. Any maintainer may do this, not just the PR owner but make sure to check to not make a duplicate. Once discussion has concluded, summarize the result of the discussion in a PR comment *before* taking any action. Then, remove the `S: Under Maintainer Discussion` label. Closing or merging should automatically apply appropriate tags and title prefixes to the discussion thread (e.g. [Approved], [Merged], [Closed] etc.), as well as close it.
-  - If the result of a Maintainer Discussion is positive and the PR has not undergone code review (meaning it is not yet ready to merge), the PR may be given the label `S: Conceptual Approval`, to show that it has been discussed with a positive outcome.
-  - If the result of a Maintainer Discussion is negative (i.e. a desire to close the PR), the result of the discussion can be cited as the reason to close the PR without explicitly requiring 2 Disapprovals.
+PRs which fix bugs, cleanup code, improve performance, or refactor systems _without_ the introduction of new features or balance changes can be processed by a single maintainer (who is not the PR author).
+The remaining decision policy requirements still apply.
 
-- If a Maintainer Discussion thread has been inactive for a week with no new messages, the Discord bot will tag the PR owner and prompt for a resolution. What this resolution is depends on the discussion, but Maintainers are encouraged to arrive at a compromise to either give the PR conceptual approval, agree to close the PR, or in rare cases ask the PR to be set to Draft in case a resolution can not be reached for some unique reason related to the PR. Other actions may also be taken. In the case the Discord bot fails, Maintainers are encouraged to do the prompting.
+PRs solely modifying sprites need only a single approval from an **Art Lead**.
+These cannot be self-approved.
 
-- All non-gamebreaking revert PRs are **required** to undergo a Maintainer Discussion *before* being created. If there is a PR that you would like to be reverted, please *manually create a thread in maint-reviews with the format REVERT-PRNumber and ping the relevant work group Maintainers.* Discussions should reach a resolution within 48 hours, if discussions have stalled notify the Game Director or a PM.
-**This does not apply for reverts made to the staging branch during the review period**, as there will be a discussion thread for the release.
+PRs solely modifying map files and/or map prototypes need only a single approval from a **Head Mapper** (including a self-approval).
 
-- When closing a PR you are **required** to give a reason explaining why the PR is being closed, and if applicable this should include an alternative solution or approach. Stale PRs may just be closed for the reason of being stale, as described under the Requirements section. 
+PRs solely containing rule changes and/or server config changes submitted by (or with written approval from) a Head Game Admin may be merged at any time with the approval of the Head Game Admin team.
 
-- When reviewing a PR use *constructive* language and avoid referring negatively to the author's ability. Strong but fair criticism of code/decisions are fine, personal criticisms are not.
+## Discussion Policy
 
-- When reviewing code, always assume that the contributor may not have your knowledge of the codebase, and provide a short explanation or reason with your review comments. You shouldn't need to code for them, but pointing them in the right direction to learn more helps build a more robust contributor base. Sometimes a newer contributor may need more help, in that case direct them to #HowDoICode or the docs. But ideally you should try to give them a short explaination on what they need to do rather than just a "change this".
+Maintainer discussions are an optional way to gain insight into general staff sentiment.
+They can be used both when there are disagreements regarding a PR and when a maintainer is not confident in the design of a PR.
 
-- Any PR that is made for illegitimate reasons, such as abuse, spam or harrassment, may be closed without following the Policy as long as a PM has given written permission, as per the procedures set out in the Requirements section.
+PRs actively undergoing a maintainer discussion should not be merged.
 
-- Not following the procedure/policy outlined in this document will result in disiplinary action being taken, at the discretion of the SS14 Wizard team.
+To begin the discussion process, add the `S: Undergoing Maintainer Discussion` tag.
+This should automatically create a post in the `#maint-reviews` discord channel with the PR's name, number, link, and appropriate tags.
 
-## Issues & Reviews
-While Issues do not have any code to review, they may still contain suggestions and feature proposals that would benefit from a Maintainer Discussion.
+Discussion can then proceed with maintainers and admins giving opinions and coming to a conclusion or compromise.
+Once a conclusion is reached or regular discussion ceases, one of the following must occur:
+- If the discussion was created due a disagreement in the PR decision,
 
-- An Issue can be given the `S: Undergoing Maintainer Discussion` label to create a discussion thread as per the process described in the Policy section. If the discussion has a positive outcome, the issue can be given the `S: Conceptual Approval` label, and any PR that references the issue without major deviation can subsequently also be given the same label, indicating no new discussion is necessary.
+
+- - If a definitive decision was reached (Approve/Close), then it should be acted upon by a maintainer.
+
+
+- - If a compromise within the scope of the PR is reached, then the PR should be approved once the compromise is implemented.
+Inability/refusal to implement the compromise should result in the closure of the PR.
+
+
+- - If no definitive decision was reached, then the PR should be closed.
+
+  
+- If the discussion was _not_ created due to a disagreement in the PR decision,
+
+
+- - If a definitive decision or reasonable compromise was reached, then it should be acted upon and/or implemented.
+
+
+- - If no definitive decision was reached, the maintainer who created the discussion may choose to resolve the PR as they see fit. 
+
+
+A positive conclusion should be indicated on the PR with the `S: Conceptual Approval` tag.
+This replaces the need for 2 design approvals (though the code still needs to be separately reviewed) and allows the PR to be merged.
+
+If the discussion has a negative conclusion, the closure message for the PR should include a brief summary of the discussion.
+This should have information about the elements that need to be addressed if a subsequent PR were to be made.
+
+## Expedited Decision-Making
+
+### Stale
+
+A PR is considered stale if it is simultaneously awaiting changes from the author and hasn't received an update for a long period of time.
+
+After 3 weeks, a maintainer should reach out to the PR author and give them a few days to confirm that they are still working on the PR.
+If they are able to or unwilling to, the PR should be marked as stale and closed.
+After 6 weeks, a PR can automatically be considered stale and closed without needing to attempt to contact the author.
+
+Note that PRs undergoing maintainer discussion or awaiting review are not considered stale.
+
+### Drafts
+
+PRs should not be marked as drafts unless there is a meaningful reason behind them.
+Simply opening an incomplete PR as a draft is not permitted and will result in immediate closure.
+
+Drafts are only permitted if a portion of the PR requires review and/or approval in order for other segments of the same PR to be completed.
+Note that this does not apply if the PR is able to be easily atomized. 
+
+### Low-Interest
+
+PRs that have not received any form of maintainer review or approval and are older than 6 weeks are considered **Low-Interest PR**s.
+
+Low-Interest PRs are subject to a expedited Decision Policy, requiring only one code and design approval to be merged or a single dissenting maintainer to be closed.
+Note that, before closing a PR due to Low-Interest, you should still briefly query maintainers to see if there would be any interest (_in the event that it simply slipped by_).
+
+### No-Impact
+
+PRs where the time and effort to review and merge the PR outweighs tangible in-game effects are considered **No-Impact PR**s.
+This does not include features that are low-priority or mundane (_clothing additions, etc._) but rather PRs which do not make substantial changes to the game.
+
+An example of a No-Impact PR would be adjusting an uplink listing's price by 1 TC.
+In most cases, this difference is unlikely to be noticeable in game. 
+Whether a PR is No-Impact is at the discretion of the maintainer team.
+
+No-Impact PRs are subject to an expedited Decision Policy, requiring only one code and design approval to be merged or a single dissenting maintainer to be closed.
+
+## Review Guidelines
+The following are general guidelines to follow when reviewing PRs. 
+These are especially important to follow for first-time contributors.
+
+- Use **constructive** language and avoid being overly negative.
+
+
+- Avoid comments that personally criticize the author.
+It's okay to critique code and decisions, but you shouldn't insult their character.
+
+
+- For people who may not be familiar with a system, try to be more thorough in your explanations.
+
+
+- When possible, direct people to either the [developer wiki](https://docs.spacestation14.com/index.html), `#howdoicode` discord channel, or alternate source for information.
+
+
+- Try to stay online for at least a few hours after reviewing PRs in order to allow contributors to contact you for additional explanations.
+
+
+- Be formal when closing PRs.
+Discourage others from engaging in rude behavior and try not to upset the PR author.
+People can often be emotional after their PR is closed.
+
+
+- For relatively minor changes, opt to simply complete them yourself and push to the PR.
+
+
+- When requesting changes to a PR be made, keep them within the scope of the PR.
+For example, while requesting small numerical adjustments on a `No C#` PR is fine, it would exceed the scope of the PR to request a new system to be added.
+In cases like these, it is best to close the PR and explain the changes that would need to be made.

--- a/src/en/wizden-staff/maintainer/review-procedure.md
+++ b/src/en/wizden-staff/maintainer/review-procedure.md
@@ -5,7 +5,7 @@ Hotfixes intended to be merged directly to the `stable` branch must follow addit
 
 Any portion of this procedure may be waived and/or modified with permission from a Project Manager or Wizard.
 
-Failure to follow this procedure may result in disciplinary action. Tread carefully, maintainer.
+Failure to follow this procedure may result in disciplinary action.
 
 ## PR Requirements
 All PRs must adhere to the [code conventions](../../general-development/codebase-info/conventions.md).
@@ -40,7 +40,7 @@ In this case, when the PR is merged, a Github issue should be created to indicat
 
 
 - If the PR has the `Changes: Sprites` label, it must additionally be approved by at least one **Art Lead** through the addition of the `S: Art Approval` tag.
-
+Changes that are solely minor sprite fixes are exempt from this.
 
 To close a PR, at **least one** of the following conditions must be met:
 - At least 2 maintainers must express wanting to close the PR or an unwillingness to merge it. 
@@ -50,35 +50,62 @@ This can be expressed either on the PR itself, or privately.
 - The PR contains content which violates Wizard Den's rules and/or code of conduct.
 
 
-- The PR author has been banned from the Wizard's Den Github and/or Discord or is otherwise unable to be communicated with.
+- The PR author has been **banned** from the Wizard's Den Github and/or Discord or is otherwise unable to be communicated with.
 
 
-- The PR is **Stale** (see section "Expedited Decision-Making").
+- The PR is **Stale**.
 
 
 - The PR has been superseded by a different PR and thus no longer needs to be merged.
 
 If a PR is closed, the maintainer must leave a message indicating the reason for its closure.
 This should be a formal message that includes all relevant information.
+If a maintainer discussion was held, it should be summarized and included here. 
 
 If there is disagreement between two maintainers about whether a PR should be merged or closed, a discussion should be held as described in the "Discussion Policy" section.
 
-### Exemptions:
+## Exemptions:
 
 ```admonish info "Use Your Head"
 The following are situations in which the typical decision policy can be modified or opted out of.
 If you do not feel confident, feel free to follow the normal process.
 ```
 
+### Fixes
+
 PRs which fix bugs, cleanup code, improve performance, or refactor systems _without_ the introduction of new features or balance changes can be processed by a single maintainer (who is not the PR author).
 The remaining decision policy requirements still apply.
+
+### Resprites
 
 PRs solely modifying sprites need only a single approval from an **Art Lead**.
 These cannot be self-approved.
 
+### Map Changes
+
 PRs solely modifying map files and/or map prototypes need only a single approval from a **Head Mapper** (including a self-approval).
 
+### Rule/Config Changes
+
 PRs solely containing rule changes and/or server config changes submitted by (or with written approval from) a Head Game Admin may be merged at any time with the approval of the Head Game Admin team.
+
+### Stale PRs
+
+A PR is considered stale if it is simultaneously awaiting changes from the author and hasn't received an update for a long period of time.
+
+After 3 weeks, a maintainer should reach out to the PR author and give them a few days to confirm that they are still working on the PR.
+If they are able to or unwilling to, the PR should be marked as stale and closed.
+After 6 weeks, a PR can automatically be considered stale and closed without needing to attempt to contact the author.
+
+Note that PRs undergoing maintainer discussion or awaiting review are not considered stale.
+
+### Drafts
+
+PRs should not be marked as drafts unless there is a meaningful reason behind them.
+Simply opening an incomplete PR as a draft is not permitted and will result in immediate closure.
+
+Drafts are only permitted if a portion of the PR requires review and/or approval in order for other segments of the same PR to be completed.
+Note that this does not apply if the PR is able to be easily atomized.
 
 ## Discussion Policy
 
@@ -120,44 +147,6 @@ This replaces the need for 2 design approvals (though the code still needs to be
 If the discussion has a negative conclusion, the closure message for the PR should include a brief summary of the discussion.
 This should have information about the elements that need to be addressed if a subsequent PR were to be made.
 
-## Expedited Decision-Making
-
-### Stale
-
-A PR is considered stale if it is simultaneously awaiting changes from the author and hasn't received an update for a long period of time.
-
-After 3 weeks, a maintainer should reach out to the PR author and give them a few days to confirm that they are still working on the PR.
-If they are able to or unwilling to, the PR should be marked as stale and closed.
-After 6 weeks, a PR can automatically be considered stale and closed without needing to attempt to contact the author.
-
-Note that PRs undergoing maintainer discussion or awaiting review are not considered stale.
-
-### Drafts
-
-PRs should not be marked as drafts unless there is a meaningful reason behind them.
-Simply opening an incomplete PR as a draft is not permitted and will result in immediate closure.
-
-Drafts are only permitted if a portion of the PR requires review and/or approval in order for other segments of the same PR to be completed.
-Note that this does not apply if the PR is able to be easily atomized. 
-
-### Low-Interest
-
-PRs that have not received any form of maintainer review or approval and are older than 6 weeks are considered **Low-Interest PR**s.
-
-Low-Interest PRs are subject to a expedited Decision Policy, requiring only one code and design approval to be merged or a single dissenting maintainer to be closed.
-Note that, before closing a PR due to Low-Interest, you should still briefly query maintainers to see if there would be any interest (_in the event that it simply slipped by_).
-
-### No-Impact
-
-PRs where the time and effort to review and merge the PR outweighs tangible in-game effects are considered **No-Impact PR**s.
-This does not include features that are low-priority or mundane (_clothing additions, etc._) but rather PRs which do not make substantial changes to the game.
-
-An example of a No-Impact PR would be adjusting an uplink listing's price by 1 TC.
-In most cases, this difference is unlikely to be noticeable in game. 
-Whether a PR is No-Impact is at the discretion of the maintainer team.
-
-No-Impact PRs are subject to an expedited Decision Policy, requiring only one code and design approval to be merged or a single dissenting maintainer to be closed.
-
 ## Review Guidelines
 The following are general guidelines to follow when reviewing PRs. 
 These are especially important to follow for first-time contributors.
@@ -175,7 +164,8 @@ It's okay to critique code and decisions, but you shouldn't insult their charact
 - When possible, direct people to either the [developer wiki](https://docs.spacestation14.com/index.html), `#howdoicode` discord channel, or alternate source for information.
 
 
-- Try to stay online for at least a few hours after reviewing PRs in order to allow contributors to contact you for additional explanations.
+- Make an effort to be available after reviewing a PR.
+You don't need to be constantly online, but if the author has questions, they should be able to get a response in a reasonable amount of time.
 
 
 - Be formal when closing PRs.

--- a/src/en/wizden-staff/maintainer/review-procedure.md
+++ b/src/en/wizden-staff/maintainer/review-procedure.md
@@ -3,30 +3,30 @@
 This documents lists the Maintainer procedure for reviewing and merging PRs to the [Space Station 14 repository](https://github.com/space-wizards/space-station-14) `master` branch. 
 Hotfixes intended to be merged directly to the `stable` branch must follow additional restrictions specified in the [Hotfix Procedure](hotfix-procedure.md).
 
-Any portion of this procedure may be waived and/or modified with permission from a Project Manager or Wizard.
+Any portion of this procedure may be waived and/or modified with written permission (_via Discord or Github_) from a Project Manager or Wizard.
 
-Failure to follow this procedure may result in disciplinary action.
+Failure to follow this procedure can result in disciplinary action.
 
 ## PR Requirements
 All PRs must adhere to the [code conventions](../../general-development/codebase-info/conventions.md).
 
-All PRs must be triaged, as per the [triage procedure](triage-procedure.md) guidelines. 
-If a PR is not triaged, this should be done at the same time as the PR is initially considered for review.
+All PRs must be triaged, as per the [triage procedure](triage-procedure.md) guidelines.
+Upon actioning on a PR (merging, closing, reviewing), if it is not triaged, the person actioning must triage the PR.
 
 All PRs must not conflict with [core design principles](../../space-station-14/core-design/design-principles.md). 
 Additionally, the PR author should describe how the changes they made fit into the game.
-Sufficiently large PRs may also warrant a **Design Doc** detailing the broader scope and purpose of their changes.
+Sufficiently large feature PRs may also warrant a **Design Doc** detailing the broader scope and purpose of their changes.
 
 All PRs that include **breaking changes** (*e.g. modifying public APIs, moving code into another namespace, changing a prototype ID, etc.*) should contain a "breaking changes" section.
 This consists of a summary of the changes as well as how to apply them.
-After the PR is merged, the maintainer should format a message containing the PR link, the entirety of the "breaking changes" section, and a ping for `@contrib-notification` and post it into the `#codebase-changes` channel of the Discord.
+After the PR is merged, the maintainer should format a message containing the PR link, the entirety of the "breaking changes" section, and a ping for `@contrib-notification` before posting it into the `#codebase-changes` channel of the Discord and publishing.
 
 All PRs must complete fill out the Github PR Template to a satisfactory level.
 This includes filling out all applicable sections and attaching media when necessary.
 
 ## Decision Policy
 2 Maintainers are required to sign off on decisions about a PR.
-One of the maintainers is allowed to be an author of the PR, but the other should be uninvolved.
+One of the sign-offs may come from a maintainer who an author or collaborator for the PR, but the other must be uninvolved.
 
 To merge a PR, **all** the following conditions must be met:
 - The PR must receive 2 approvals for both **Code** and **Design**, given in the form of an approval checkmark on the PR's Github page.
@@ -68,7 +68,7 @@ If there is disagreement between two maintainers about whether a PR should be me
 
 ```admonish info "Use Your Head"
 The following are situations in which the typical decision policy can be modified or opted out of.
-If you do not feel confident, feel free to follow the normal process.
+If you do not feel confident, feel free to follow the normal process or ask a fellow Maintainer for assistance.
 ```
 
 ### Fixes
@@ -83,7 +83,7 @@ These cannot be self-approved.
 
 ### Map Changes
 
-PRs solely modifying map files and/or map prototypes need only a single approval from a **Head Mapper** (including a self-approval).
+PRs solely modifying map files and/or map prototypes need only a single approval from a **Head Mapper**. These may be self-approved.
 
 ### Rule/Config Changes
 
@@ -173,7 +173,7 @@ Discourage others from engaging in rude behavior and try not to upset the PR aut
 People can often be emotional after their PR is closed.
 
 
-- For relatively minor changes, opt to simply complete them yourself and push to the PR.
+- For relatively minor changes, opt to simply [complete them yourself](https://cli.github.com/manual/gh_pr_checkout) and push to the PR.
 
 
 - When requesting changes to a PR be made, keep them within the scope of the PR.

--- a/src/en/wizden-staff/maintainer/review-procedure.md
+++ b/src/en/wizden-staff/maintainer/review-procedure.md
@@ -3,7 +3,7 @@
 This documents lists the Maintainer procedure for reviewing and merging PRs to the [Space Station 14 repository](https://github.com/space-wizards/space-station-14) `master` branch. 
 Hotfixes intended to be merged directly to the `stable` branch must follow additional restrictions specified in the [Hotfix Procedure](hotfix-procedure.md).
 
-Any portion of this procedure may be waived and/or modified with written permission (_via Discord or Github_) from a Project Manager or Wizard.
+Any portion of this procedure may be waived and/or modified with written permission (_via Discord or Github_) from a Lead Maintainer, Project Manager or Wizard.
 
 Failure to follow this procedure can result in disciplinary action.
 
@@ -21,12 +21,12 @@ All PRs that include **breaking changes** (*e.g. modifying public APIs, moving c
 This consists of a summary of the changes as well as how to apply them.
 After the PR is merged, the maintainer should format a message containing the PR link, the entirety of the "breaking changes" section, and a ping for `@contrib-notification` before posting it into the `#codebase-changes` channel of the Discord and publishing.
 
-All PRs must complete fill out the Github PR Template to a satisfactory level.
+All PRs must completely fill out the Github PR Template to a satisfactory level.
 This includes filling out all applicable sections and attaching media when necessary.
 
 ## Decision Policy
 2 Maintainers are required to sign off on decisions about a PR.
-One of the sign-offs may come from a maintainer who an author or collaborator for the PR, but the other must be uninvolved.
+One of the sign-offs may come from a maintainer who is an author or collaborator for the PR, but the other maintainer must be uninvolved.
 
 To merge a PR, **all** the following conditions must be met:
 - The PR must receive 2 approvals for both **Code** and **Design**, given in the form of an approval checkmark on the PR's Github page.

--- a/src/en/wizden-staff/maintainer/review-procedure.md
+++ b/src/en/wizden-staff/maintainer/review-procedure.md
@@ -154,6 +154,9 @@ These are especially important to follow for first-time contributors.
 - Use **constructive** language and avoid being overly negative.
 
 
+- Try not to be _overly_ vulgar or swear in a derogatory way.
+
+
 - Avoid comments that personally criticize the author.
 It's okay to critique code and decisions, but you shouldn't insult their character.
 


### PR DESCRIPTION
# About This PR
This revision aims to clarify and streamline the PR review procedure for the main Wizden repo.

This is not the final document that will be merged. Changes are to be expected. 

A summary of the changes can be found below:

Intro:
- The intro of the procedure now includes better reference to the hotfix policy, broad PM/wizards exceptions for the procedure, and the disciplinary info.

Requirements:
- The "Requirements" section has been revised to resemble a checklist of things that must be completed.
- Code conventions are no longer indicated to be optional.
- Triaging is no longer indicated to be optional
- The necessity of a design document has been clarified 
- Abiding by the PR template has been added as a requirement.

Decision Policy:
- A new section, titled "Decision Policy" has been created out of the latter half of the existing policy requirements.
- The two-person sign-off policy has been revised to indicate that at least one of the maintainers signing off on the PR must be uninvolved in its creation.
- The requirements to merge a PR has been reformatted as a checklist.
- Policy surrounding PR approval has been streamlined and simplified significantly. Approval is now more directly split into "code" and "design" and references to the tagging procedure have been omitted in favor of using the default github checkmarks with additional comments for more information.
- A secondary requirement of resolved changes has been added. This includes a clause for deferring changes to a later point in time.
- The conditions to close a PR have been moved to a secondary list.
- Willingness to close a PR no longer needs to be specified publicly in the PR comments.
- Additional conditions for which a PR may be closed have been added. These are frequently used already but weren't formally specified:
- - PR contains offensive content or breaks community rules (spam, harassment)
- - The PR author has been banned
- - The PR author is unreachable
- - The PR is stale
- - The PR has been superseded by another PR.

Exemptions:
- Double sign-off exemption for bugfixes, refactors, cleanup, and performance changes has been reworded to omit references to PR labels. This makes processing more clear if a PR has not been triaged.
- Similar to head mappers, gives art leads the ability to merge resprite PRs with a single approval.
- Clarified timeline of stale PRs. Also added ability to immediately close PRs which have been inactive for a significant duration without needing to check with the author.
- Added sub-section clarifying the role of draft PRs. This includes stipulations for when they are not permitted and can be immediately closed.

Discussion Policy:
- Renamed "policy" section to better indicate what it refers to
- Removed technical information about assigning ownership over PRs during discussion. This is rarely followed and overly complicated to do per-PR.
- Added additional section to discussion policy to indicate how discussions results should be acted upon under different circumstances.
-  - For discussions resolving maintainer disagreements, a positive conclusion or a compromise must be reached, or the PR is to be closed. Inconclusive results or a lack of engagement is defaulted to a closure.
- - For discussions not resolving maintainer disagreements, inconclusive results or lack of engagement gives the maintainer reviewing the PR free reign over its approval.
- Removed stipulation requiring reverts to have pre-approval before the PR is created. This is fairly nonsensical as it prevents non-staff outright from reverting any feature.

Review Guidelines:
- Removed information pertaining to issue approval. AFAIK this is basically never done and would be better suited as a design document.
- Added bullet point information about performing reviews on PRs.

