### PR TITLE
GitHub Moderation Guidelines

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -41,6 +41,7 @@ General Development
 - [Work Groups](en/general-development/work-groups.md)
 - [Game Area Design Documents](en/general-development/game-area-design-doc.md)
 - [Contributing Translations](en/general-development/contributing-translations.md)
+- [Github Moderation Guidelines](en/general-development/github-moderation-guidelines.md)
 
 SS14 By Example
 ===============

--- a/src/en/general-development/github-moderation-guidelines.md
+++ b/src/en/general-development/github-moderation-guidelines.md
@@ -1,0 +1,33 @@
+# Github Moderation Guidelines
+
+This document clarifies guidelines for Github moderation in regards to the project's Code of Conduct. Github Moderators are expected to adhere to these guidelines as a baseline for actions taken on the Github repository, but may deviate if they believe it is in the best interest of the community. 
+
+Note: If you believe these guidelines were not followed or were deviated from without good reason, you are encouraged to to contact staff via [Discord](https://discord.ss14.io/) or [the forums](https://forum.spacestation14.com/), appeal your Github ban [on the forums](https://forum.spacestation14.com/c/ban-appeals/appeals-github/38), or make a [staff complaint](https://forum.spacestation14.com/t/staff-complaint-instructions-and-info/31). Incorrect enforcement of the [Code of Conduct](https://github.com/space-wizards/space-station-14/blob/master/CODE_OF_CONDUCT.md) will not result in disciplinary action for staff when done in good faith, and is reserved for extreme cases where good faith does not exist.
+
+## Moderative Actions
+
+### Permanent Bans
+
+Content that violate the examples listed under the "**Be careful in the words that you choose.**" bulletpoint of the [Code of Conduct](https://github.com/space-wizards/space-station-14/blob/master/CODE_OF_CONDUCT.md) will result in an immediate permanent non-appeal repository ban and report to the Github org.
+
+This may also apply should the offending content be located outside the SS14 Github, such as on the Wizden Discord server, forums or elsewhere, at the Github Moderator's discretion. PRs created by the offending user should be closed, though its contents may be picked up by another contributor and reused in a new PR should the license permit it.
+
+### Other Actions
+
+As listed under the "**On Community Moderation**" section, content/comments that create an unwelcoming atmosphere for the project may result in moderative actions. Github Moderators have the following actions at their disposal:
+- Hiding comments.
+  - This should preferably be used for comments that are off-topic or otherwise inoffensive but fail to contribute to the discussion. Such comments should be marked as "Off-Topic" or "Spam"; while the interface provides other reasons for hiding a comment, they are better served below.
+- Removing content & Providing a 12h Github ban.
+  - For content/comments that are given in a non-constructive manner (examples listed in the [Code of Conduct](https://github.com/space-wizards/space-station-14/blob/master/CODE_OF_CONDUCT.md)), the content may be removed even if it is partially constructive. Should this be necessary, the offending user should be given a 24 hour Github ban with the Ban Message listed further below. While a ban may sometimes seem excessive, this is the only way we can communicate directly to a user that they have had actions taken against them.
+- Long-duration Github bans.
+  - Should a user repeatedly break the Code of Conduct, a Github ban for a longer duration may be warranted. The duration should be between 7 days to 1 month, at the Github Moderator's discretion. Anything longer should be an appeal-only ban.
+- Appeal-only bans.
+  - An appeal-only ban may be given instead of a long-duration ban. These bans may only be [appealed on the forums](https://forum.spacestation14.com/c/ban-appeals/appeals-github/38), at the soonest 6 months after the ban was issued.
+
+### Ban Message
+
+```admonish quote
+You have received a [Duration] Github ban due to your conduct in [PR/Issue Number], due to [Reason] violating our Code of Conduct. For more information, please read the SS14 Github Moderation Guidelines: https://docs.spacestation14.com/en/general-development/github-moderation-guidelines.html
+```
+
+Example reasons (not exhaustive): `Unnecessary Hyperbole`, `Bringing up unrelated PRs/balance changes`, `Hostile Tone`, `Off-Topic Comment`.


### PR DESCRIPTION
This document adds guidelines for how the SS14 Github should be moderated. It gives a fairly wide berth for moderators to make decisions (as long as they're done in good faith). 

This PR references a Code of Conduct, which can be found in this PR: (Link pending)