### PR TITLE
Add disclaimer to the changeling design doc

### DIFF
--- a/src/en/space-station-14/round-flow/proposals/changeling.md
+++ b/src/en/space-station-14/round-flow/proposals/changeling.md
@@ -1,5 +1,5 @@
 ```admonish warning
-This design doc is currently actively being rewritten and should not be used as the basis for a PR. IF you are intersted in helping out contact Slarti and Scarky first, who are leading the changeling strike group.
+This design doc is currently actively being rewritten and should not be used as the basis for a PR. If you are intersted in helping out contact Slartibartfast and ScarKy0 first, who are leading the changeling strike group.
 Also check the [changeling development tracker issue](https://github.com/space-wizards/space-station-14/issues/39439) where we will list current bugs and the next steps in the development.
 ```
 # Changeling antagonist

--- a/src/en/space-station-14/round-flow/proposals/changeling.md
+++ b/src/en/space-station-14/round-flow/proposals/changeling.md
@@ -1,8 +1,7 @@
-:::info
+```admonish warning
 This design doc is currently actively being rewritten and should not be used as the basis for a PR. IF you are intersted in helping out contact Slarti and Scarky first, who are leading the changeling strike group.
 Also check the [changeling development tracker issue](https://github.com/space-wizards/space-station-14/issues/39439) where we will list current bugs and the next steps in the development.
-:::
-
+```
 # Changeling antagonist
 
 | Designers            | Implemented | GitHub Links |

--- a/src/en/space-station-14/round-flow/proposals/changeling.md
+++ b/src/en/space-station-14/round-flow/proposals/changeling.md
@@ -1,5 +1,5 @@
 ```admonish warning
-This design doc is currently actively being rewritten and should not be used as the basis for a PR. If you are intersted in helping out contact Slartibartfast and ScarKy0 first, who are leading the changeling strike group.
+This design doc is currently actively being rewritten and should not be used as the basis for a PR. If you are interested in helping out contact Slartibartfast and ScarKy0 first, who are leading the changeling strike group.
 Also check the [changeling development tracker issue](https://github.com/space-wizards/space-station-14/issues/39439) where we will list current bugs and the next steps in the development.
 ```
 # Changeling antagonist

--- a/src/en/space-station-14/round-flow/proposals/changeling.md
+++ b/src/en/space-station-14/round-flow/proposals/changeling.md
@@ -1,3 +1,8 @@
+:::info
+This design doc is currently actively being rewritten and should not be used as the basis for a PR. IF you are intersted in helping out contact Slarti and Scarky first, who are leading the changeling strike group.
+Also check the [changeling development tracker issue](https://github.com/space-wizards/space-station-14/issues/39439) where we will list current bugs and the next steps in the development.
+:::
+
 # Changeling antagonist
 
 | Designers            | Implemented | GitHub Links |


### PR DESCRIPTION
It is actively being rewritten and we need more refactoring before abilities can be added.
I'm adding a disclaimer to prevent tons of PR without prior approval from being made.