### PR TITLE
Release Procedure fix

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -345,6 +345,7 @@ Staff
   - [Review Whitelist](en/wizden-staff/maintainer/review-whitelist.md)
   - [Hotfix Procedure](en/wizden-staff/maintainer/hotfix-procedure.md)
   - [Triage Procedure](en/wizden-staff/maintainer/triage-procedure.md)
+  - [Release Procedure](en/wizden-staff/release-procedure.md)
 - [Space Wizards Role Hierarchy](en/wizden-staff/space-wizards-role-hierarchy.md)
 - [Space Wizards Maintainer List](en/wizden-staff/space-wizards-maintainer-list.md)
 - [Staff Policy](en/wizden-staff/staff-policy.md)


### PR DESCRIPTION
Actually release the release procedure. The page was created, but it was not added to the page index, so it was not listed and could not be seen/reached