### PR TITLE
[DRAFT] Medical design doc(s)

### DIFF
--- a/src/en/space-station-14/departments/medical.md
+++ b/src/en/space-station-14/departments/medical.md
@@ -1,43 +1,55 @@
-```admonish warning "Attention: Placeholder!"
-This section is a placeholder, pending a design-doc being created by the related work-group
-```
-
 # Medical
-Responsible for causing patient's skeletons to disappear
+
 
 ## Concept
-> A high-level conceptual overview of what this department does. This is generally 1-2 paragraphs and should reflect a high level view of what this department brings to the player and the game. 
-
-## Player Story
-> A short (1-2 paragraph) story from the perspective of someone playing a role in this department. This is effectively a story of the ideal experience of a player interacting with these mechanics/systems. 
+Medical as a department is primarily tasked with keeping the crew alive and healthy. 
+The challenge of that very simple task is that the crew lives in a tin can that is prone to very bloody and violent accidents and disasters.
+It's medicals job to be able to respond to a variety of different injuries and deaths, from a variety of different sources and to diagnose and cure so that the crew can get back to work or at least limp their way to the evacuation shuttle.
+The tools medical uses should be scarce, but never scarce enough to halt the department, should be time consuming such that death is dangerous, but never time consuming enough that there's a lot of waiting involved in healing, and should keep medical constantly moving, but not so constant that it becomes overwhelming or unreasonably swamped. 
+Almost no injuries should be unrecoverable given you have the right tools, and any injuries that are unrecoverable shouldn't waste medical's or the dead player's time.
 
 ## Design Pillars
-> A group of simple high-level ideas that embody this department. These are usually expressed with singluar words or short phrases, but may also include a *short* one sentence explaination. Game pillars are what makes the *identity* of the department. 
+Medical as a department 
 
-> Pillars are there to act as guides when creating new mechanics or interactions, they serve as the measuring posts to make sure that what you are trying to do will fit in the department gameplay. 
+### Pillar 1: Injuries should match the danger of the source.
+ The difference between a common workplace accident and getting shot to pieces shouldn't be one number being higher.
 
-> To acheive this you want pillars that are concrete enough to get your concept across but broad enough that there is some room of interpretation and discussion.
+  > Common injuries should be easier to treat, almost trivially so. Something you come into medical for, get a band aid and a pill and then be on your way as to not slow down the department.
 
-### Pillar_1:
- > Breif Pillar Description
+  > Rarer job hazards should require some care and maybe more intensive treatments depending on the degree of the mistake. Got bitten a few times by a carp and lost your hand? A prosthetic limb can fix that. Decided to hang around the singularity for a bit too long? You'll probably need a coupe new organs alongside those radiation burns. 
 
- ### Pillar_2:
- > Breif Pillar Description
+ > And most important, if someone really wants you dead then medical shouldn't be able to reverse that easily. 
+
+ ### Pillar 2: Treatment should be reactive.
+ Nobody likes doing the same thing over and over again. That's boring! As much as possible injuries should be dynamic and interesting. 
+ 
+ > There should be no cure all medicine that is always the correct option to use. Any that could exist should be limited by drawbacks of side effects, scarcity or exclusiveness.
+ 
+ > Real injuries shouldn't be static, gunshot wounds should worsen over time if left untreated, a patient in crit should get worse and become harder to heal, a dead body should rot and that rot should make getting them back up harder and harder the more time passes. A dying crewmember should need to be monitored because no medicine should be a cure all. You should have to put effort into treating bad injuries, it shouldn't just be about waiting for a number to go up after clicking 1-3 times with the correct healing item. 
+
+### Pillar 3: Medicine should be interesting
+Players should want to know how to be a doctor, not only for the purpose it serves but for the depth and complexity involved.
+
+> Everything from treatment, to chemistry, to surgery should have mechanical depth where knowledge and creativity is rewarded and experimentation is encouraged. 
+
+> Getting the best numbers should be mechanically discouraged by having a wide variety of options available. The same injury might call for different treatments depending on context, some poisons might suit some situations better than others. Any "best of their class" meta items or tactics should be discouraged through complexity and should never so heavily outweigh the simpler options that it becomes a burden to not understand them. Not knowing the meta shouldn't put you at a major disadvantage. 
+
+### Pillar 4: Information is a resource
+The information that is communicated to a doctor should be something doctors have to actively try and get. Medical scanners shouldn't be an end all be all. As with Pillar 2, no treatment should be a cure all, and therefore no source of information should trumph another. 
+
+> Getting information from a patient should be the fastest and easiest way to diagnose, but not the only option for obvious reasons.
+
+> Handheld items should only give some of the story, with the rest having to be intuited through knowledge or context.
+
+> No information should be completely obscured. There should be fallbacks in case other methods of information gathering fail so that a medical player never feels stuck. These fallback methods should be always available but should be inconvenient so players don't rely on them and instead learn to master their medical skills.
 
 ## Objectives
-> What is this department's objective when it comes to the round? Do they have a unique failure condition? If so, what is it? How does this department's objectives interact with the rest of the station?
+Medical is arguably the most important department for the crew round flow wise. If a player can trust that the medical department will be there to catch them when they fall, they're more likely to go out and make mistakes, and mistakes are fun. A traitor trying to assassinate their target should be having to make sure that medical wont be able to save them in addition to security not being able to catch them. A nuclear operative should be thinking about and accounting for the fact that medical is going to be turning dead bodies into walking obstacles. 
 
-## Progression
-> How does the *gameplay* of this department change over the course of a round? Are there unlocks? Are players collecting/spending resources? Is this progression tied/related to other departments? If so how?
+From a doctor's perspective, they should be a neutral but station leaning party. It's their job to keep these crewmembers alive in spite of everything and they should at least have a vague idea of how to handle that.
 
-## Flow
-> How does the *experience* of the player change over the course of a round? Are players constantly running around putting out fires or are there breaks in the action? Do players need to wait on other departments as pre-requisites for their own gameplay, or is this department fairly self-sufficent?
+An experienced doctor should never feel overwhelmed but their work also shouldn't feel mundane. Each injury should be a puzzle to solve, some more simple than others but none feeling impossible or discouraging to solve. Intuiting and gathering information should be their most important skill, such that they always have to put some effort in to do their job well. 
 
-## Mechanics
-> What major mechanics does this department use and how are they connected to this department.
+At the same time, medical shouldn't have such a high learning curve or barrier to entry that it becomes obtuse. Tools should be intuitive, information should be immediately understood upon being recieved and the potential solutions obvious. While problems may worsen over time, the stress shouldn't be about "I have no clue what to do" but instead "I'm not sure which option is the best one right now". 
 
-### Mechanic_Placeholder1
-> Each mechanic should have its own subheading and should contain a *short high-level* overview of the mechanic and how it is used by this department. Each mechanic should also link their associated design document as the subheading.
-
-### Mechanic_Placeholder2 (Not Implemented Yet)
-> Mechanics that are unimplemented should be marked with (Not Implmented Yet) and should link the associated design proposal if it exists.
+Medical should try to stay within the medical department. Their best tools should be static such that a traitor can't run around with better healing than what the security officer they just shot is going to be getting on their medical bed that they're strapped to. Nobody should be able to become a perfect one crewmember walking medical department. At the same time, a doctor should be able to reasonably handle treating a single patient or a group of patients on their own. Given the nature of the game, there's a very high chance their will be more bodies in the department than there are doctors. 

--- a/src/en/space-station-14/medical-workgroup.md
+++ b/src/en/space-station-14/medical-workgroup.md
@@ -1,0 +1,46 @@
+# Medical Work Group Document
+
+## Overview
+Given the split, unbalanced, and blatantly unfinished nature of this game's medical system it's necessary that the medical workgroup's responsibilities and limitations are in a public space such that they can be easily understood and read.
+
+The medical workgroup is responsible for the medical system of Space Station 14 which includes but is not limited to: Damage, BodySystem, Reagents, Metabolism, BodySystem, the Medical Department, and Chemistry. The goal of the medical workgroup is to nearly completely overhaul all of these systems to match the mechanical depth of Space Station 13's various medical systems.
+
+To accomplish this impossible task I have set aside three basic responsibilites of the workgroup.
+
+### Responsibiltiy 1: Maintaining Current Medical Balance
+
+This comprises of two things, keeping medical balance static as microbalancing is bad and takes away from work we could put towards making it better, but also doing active maintenance on it. Fixing bugs, adding small features, code improvements, cleanup ect. 
+
+Upstream medical balance should be in a "acceptable enough" state, and big changes should only be made if something has gone horribly wrong or needs fixing. New features should be scrutinized and only accepted if they are small and easily reversible or portable to a new medical system. Larger medical changes that may interfere with development should either be redirected to the development of a new medical system if possible, or closed and or frozen if not. 
+
+Any new PRs for current med should be compliant with the great debodying no matter what or be closed at the discretion of the medical workgroup.
+
+### Responsibility 2: The Great Debodying Cleanup
+
+The bigger responsibility is "The great debodying." This must be enforced if we are to have a body system and complex medical systems.
+
+All debodying should be compatible with the goals of the new medical system. Debodying is the most important step of the process because it makes building a new medical system a lot easier and gives us a lot more options to make changes without compromise.
+
+Debodying comprises of two things:
+
+#### 1. Removing the depdencency of all systems reliant on bodysystem or organ code in favor of more generic methods that anything can hook into.
+Previous attempts to overhaul medical came with the assumption that bodysystem would be on every living entity, such that it was often used as a check for if an entity was a mob that was alive. This resulted in extremely rigid code that assumed that many entities would not only have a body, but that there would be specific organs that did specific things and if you wanted something even slightly different, you'd have to make a brand new system for it.
+
+Needless to say, this coding approach does not flex the benefits of ECS and is not up to modern wizden coding standards. As a result, all of this code needs to be completely refactored or thrown out. 
+
+As a general rule of thumb: Anywhere that checks for a body component, we should be raising handleable events that body system hooks into. And we should make as little assumptions as reasonably possible about what these events are doing. The less rigid the code, the more creatively contributors can use the system and the more flexible we can be with a new medical system. 
+
+#### 2. Refactoring and cleaning up reagent code and attached reactive systems.
+Reagent code is messy, broken, and comes with a lot of assumptions and workarounds that aren't nice.
+
+As a goal, reagent code should be easy to understand, have a usable API, and its features should justify themselves. A lot of reagent code is made with the assumption it would be used for something someday, but that day never came to fruition. 
+
+### Responsibility 3: Psycho-Med
+
+Psycho med is the name we've given to the current medical project, and as a result the third responsibility is developing that system.
+
+Because of the massive changes required to make a new medical system happen, psycho-med development will need to be done in parallel to current upstream and reviewed and tested off of upstream. From there the system can be merged upstream in large feature complete chunks that would normally be unreviewable due to size and complexity. 
+
+This gives us the leverage to make big sweeping changes while still being able to adequately test them and without the worry of breaking things or having to do big rollbacks that result in setbacks, delays, and loss of morale. 
+
+As of writing, Psycho-Med has no current singular document and due to the current size of the team one isn't needed. And as we are going to be merging Psycho-Med in large chunks, the need of a doc to close issues is not needed because any upstream medical changes fall under responsibilities 1 and 2. 


### PR DESCRIPTION
I have made two documents in related to the (currently un)official medical workgroup.

The documents comprise of a general overview of what medical gameplay should look like from an overarching design standpoint, and a second which goes over the goals and responsibilities of the medical workgroup.

I saw it as important to include the latter since due to the current and unique nature of medical development, we need a bit more freedom in terms of managing, merging, freezing, and closing medical related PRs than a design doc would offer. It also clearly outlines the scope of what we're doing so if people have questions they can get answers, and if people want to contribute they can know what they can contribute to and how.