### PR TITLE
Simplify policy for closing old PRs

### DIFF
--- a/src/en/wizden-staff/maintainer/review-procedure.md
+++ b/src/en/wizden-staff/maintainer/review-procedure.md
@@ -76,6 +76,13 @@ This can be expressed either on the PR itself, or privately.
 
 - The PR has been superseded by a different PR and thus no longer needs to be merged.
 
+- If a PR is not a refactor, bugfix or code cleanup it can be closed due to low interest if it is older than 3 months and has not received a review from a maintainer. If another maintainer disagrees with closing the PR they are free to reopen it if they leave a review. When closing you can use the following template:
+  ```
+  Hello, and thank you for your contribution!
+  At the moment maintainers are facing a high backlog and unfortunately can’t review every single pull request. For this reason, we’ll need to close this one.
+  Feel free to further contribute in the future.
+  ```
+
 If a PR is closed, the maintainer must leave a message indicating the reason for its closure.
 This should be a formal message that includes all relevant information.
 If a maintainer discussion was held, it should be summarized and included here.


### PR DESCRIPTION
This is a follow-up to an internal discussion we had today.

This change makes it easier for maintainers to close PRs that are of low interest. The high backlog is simply not something we can tackle at the moment with the current maintainer resources. In a perfect world we would be able to give every PR the attention it deserves, but at this point we have to accept that not all PRs will be able to be reviewed, and I think we have to learn to say no to contributions if we ever want to reduce the backlog.

This change is intended for low-effort, fluff, microbalance and other PRs where reviewing them takes more time than the impact on the game is worth. Maintainer burnout is real, and this should help reduce the pressure a little and allow us to focus more on the important PRs that are waiting on a review.

#### I like this PR, I don't want it closed!
No problem, just leave a review or ask another maintainer to do so and it will be exempt from this rule.

#### Another maintainer closed a PR I liked!
No problem, you are allowed to re-open it as long as you leave a review. This makes sure that the PR won't end up in limbo where it cannot be closed but does not get reviewed either.

#### Won't the author be angry when their PR was closed after 3 months?
Fair, but the current way this ends in many cases is that contributors have to beg for reviews, don't get one and the PR merge conflicts and is eventually closed after rotting for a while. A honest "no" is a way more professional answer than simply ignoring the problem until it goes away on its own. Getting buried among a 1000 other PRs and then be forgotten about is not a good experience for contributors either.

#### Is the concern label not enough?
The concern label helps but kinda serves a different purpose. I don't have conceptual concerns with fluff or microbalance PRs unless there is something majorly wrong with it. Fluff is nice, but simply low priority.

#### This won't be enough to reduce the backlog, and we should not close this many PRs!
This change is not intended to completely solve the backlog problem by its own, but just reduce the pressure on maintainers a little. And the intention is not to Thanos snap the repository, but to make it easy for maintainers to handle PRs that have a higher review effort than the positive impact on the game is worth.
If this change is accepted I will probably go through the PR list and will aim to close about 50-100 low interest PRs as a start and then let it sink in for a while to see how the PR numbers develop, see if there is any feedback and eventually repeat a while later.

#### We need some exact rules which type of PR should be closed and which not!
Our policies are already quite complicated and the intention of this change is to make it *simple* for maintainers to close PRs without having to consult others or otherwise spend a lot of time, so that we are able to better deal with a large amount of PRs in a reasonable amount of time. I get that it won't be perfectly fair to every single contributor, but neither is leaving important PRs in review hell. And I trust the judgement of our maintainer team to be reasonable when applying this policy.

#### If the backlog is reduced this policy should be removed again!
Due to the time limit of 3 months this policy is kinda self-regulating, meaning if we reach a resonable review time for PRs it will automatically not apply anymore.

#### Can't we do this together with multiple maintainers over voice chat?
Yes, that works great for PRs that need a conceptual discussion or are low-hanging fruits and I hope that we continue the voice chat sessions. But discussing every single small PR with 5+ maints again takes a lot of cumulative effort, during which a single maintainer might as well just review it. The whole point of this change is to allow maintainers to handle a PR in less than a minute without having to consult others or to check complicated policies. So I think both of these approaches will complement each other and will hopefully allow us to finally reduce the backlog.