### PR TITLE
Fix mapping guidelines headers in departmets 

### DIFF
--- a/src/en/space-station-14/mapping/guidelines.md
+++ b/src/en/space-station-14/mapping/guidelines.md
@@ -140,7 +140,7 @@ Optional
 - Water Cooler
 - Secway Spawner + Keys
 
-### Wardens Office
+#### Wardens Office
 Required
 - Warden’s Locker [filled]
 - Criminal Records Computer
@@ -530,7 +530,7 @@ Optional
 - Extra Botany Tools
 - Windows to kitchen or chem or both
 
-##### Bar
+#### Bar
 Required
 - Booze Dispenser
 - Soda Dispenser

--- a/src/en/space-station-14/mapping/guidelines.md
+++ b/src/en/space-station-14/mapping/guidelines.md
@@ -404,7 +404,7 @@ Optional
 - First Aid Kit
 
 ## Engineering
-##### Main Engineering
+#### Main Engineering
 
 Required
 - Engineer Lockers
@@ -473,7 +473,7 @@ Required
 Required
 - Telecommunications Servers
 
-##### Atmospherics
+#### Atmospherics
 Required
 - Atmospheric Technician’s Locker [filled]
 - Working waste loop


### PR DESCRIPTION
Fixed # count headers for 
warden 
bar 
main engineering
Atmospherics

<img width="297" height="300" alt="image" src="https://github.com/user-attachments/assets/b5edb440-d702-42bb-aa85-f2a1e58159d0" />
<img width="282" height="478" alt="image" src="https://github.com/user-attachments/assets/bd2a42d4-8af9-4aa5-a9ce-db2b671132c4" />

why? 
Proper alignment is necessary to make it look good.
