### PR TITLE
Add Obsidian to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
 book
+
+# Jetbrains (Rider, etc) project config folder
 .idea/
 
-# editor files
+# Editor files
 .*~
 *.swp
 
-# VSCodium files
+# VSCode and VSCodium project config folder
 .vscode/
+
+# Obsidian vault config folder
+.obsidian/


### PR DESCRIPTION
# Summary

Obsidian is a glorified note-taking app with synced backup, but provides a nicer Markdown document-writing experience than, VSCode (esp. on mobile). Its config folder is .obsidian and adding it to the .gitignore means it doesn't clutter things if someone chooses to use it as their editor.