### PR TITLE
Update server hosting tutorial by removing DOTNET_ReadyToRun

### DIFF
--- a/src/en/general-development/setup/server-hosting-tutorial.md
+++ b/src/en/general-development/setup/server-hosting-tutorial.md
@@ -168,7 +168,6 @@ Environment variable to enable full dynamic PGO, which drastically improves perf
 ```
 DOTNET_TieredPGO: 1
 DOTNET_TC_QuickJitForLoops: 1
-DOTNET_ReadyToRun: 0
 ```
 
 Environment variable to enable AVX operations across the codebase. Depending on your processor, this might hurt performance instead of improving it, otherwise it may improve atmos performance.


### PR DESCRIPTION
Removed the DOTNET_ReadyToRun environment variable from the server hosting tutorial. This env var only matters during the build process, dunno why we would set it when running the server