### PR TITLE
Completely rewrite the pull request review guidelines

### DIFF
--- a/src/en/general-development/codebase-info/pull-request-guidelines.md
+++ b/src/en/general-development/codebase-info/pull-request-guidelines.md
@@ -73,7 +73,7 @@ You must fill out the Pull Request Template when submitting your pull request to
 1. The _About_ section must explain only what the PR does.
 2. The _Why/Balance_ section must justify the changes in your PR.    
    1. Small bugfixes do not need a lengthy justification.
-   2. If a pull request is balance-centric, the justification should be lengthy and properly explain why the change is needed.
+   2. If a pull request is balance-centric, the justification should properly explain **why** the change is needed.
    3. Justifications that only explain what the pull request *does* or the *effects* that the changes have are not acceptable.
    4. Major content additions should align with the core design principles. Sufficiently large content additions might warrant a design document to detail the broader purpose of the changes and how they fit into the current game.
 3. The _Technical Details_ section should give a high-level overview of the changes.

--- a/src/en/wizden-staff/maintainer/review-procedure.md
+++ b/src/en/wizden-staff/maintainer/review-procedure.md
@@ -47,14 +47,19 @@ Pull requests must pass code review in order to be merged.
 The number of reviews required are determined by the type of pull request being reviewed.
 
 ```admonish note
-Pull requests may be reviewed, approved, and merged by a single maintainer in specific circumstances. When a maintainer does so, the maintainer is expected to provide concrete and valid reasoning for doing so. For example, a maintainer that is known for reviewing and making prediction PRs can probably process a prediction PR by themselves.
+Pull requests may be reviewed, approved, and merged by a single maintainer in specific circumstances.
+When a maintainer does so, the maintainer is expected to provide concrete and valid reasoning for doing so.
+For example, a maintainer that is known for reviewing and making prediction PRs can probably process a prediction PR by themselves.
 ```
-
-If the pull request does not line up with any category listed here, defer to two approvals for a pull request.
 
 A pull request created by a Maintainer has one approval by default.
 However, Maintainers cannot self-approve pull requests that would only require one approval to merge.
 For example, a maintainer cannot create a PR for a small bugfix and then instantly merge it after - it must be reviewed by another maintainer.
+
+#### Examples
+```admonish info
+If the pull request does not line up with any category listed here, defer to two approvals.
+```
 
 - **One Approval:**
   - Light code cleanup
@@ -163,14 +168,14 @@ Maintainers have direct push access to the Docs repo and are encouraged to use i
 PRs that update instructional or reference documentation (including but not limited to setup guides, style guides, system documentation) require only a single approval before it can be merged.
 Likewise, only a single maintainer needs to express concern to close it.
 
-Note that this does not apply to changes to internal procedure or other modifications which require voting or group deliberation according to relevant policy.
+Note that this does not apply to changes to internal procedure or other modifications that require voting or group deliberation according to relevant policy.
 
 #### Design Documents
-Major PRs that introduce or change a design document should seek either two maintainer approvals or more.
-If the addition is large enough, a maintainer can call a vote for the design document, however this should only be done when the scope of the pull request warrants it.
+Major PRs that introduce or change a design document should require at least two maintainer approvals.
+If the addition is large enough, a maintainer can call a vote on the design document; however, this should be done only when the scope of the pull request warrants it.
 
 Major game features usually follow the below dynamic:
-1. A contributor creates a preliminary design document demonstrating what they would like to add, offering a high-level overview on how it fits into the game.
+1. A contributor creates a preliminary design document demonstrating what they would like to add, offering a high-level overview of how it fits into the game.
 2. Maintainers discuss the document in an informal discussion. If most agree, the document is marked with `S: Doc Approved`, and the contributor can start work on the actual feature. As the feature is developed, the document is updated if necessary.
 3. Once the content-side implementation is ready to be merged, both the design document and the content pull request are merged in tandem.
 


### PR DESCRIPTION
This pull request completely obliterates and rewrites the pull request review guidelines from the ground-up.

Upstream has been tangled in endless and mindless bureaucracy for years. The policy has quite simply failed us - game changes are caught up in theoretical balancing and discussion instead of being disregarded or put to the test.

The following policy ultimately aims to achieve the following:
- **Dramatically simplify policy.**
  - The previous policy is a product of like 3 years worth of changes all being merged into one amalgam of a document.
- **Reduces the required amount of maintainer input for small fry pull requests, including content pull requests.**
  - These types of pull requests are basically treated as a boolean MERGE or CLOSE.
- **Removes the distinction between conceptual approval and code approval for GitHub reviews.**
  - They are rarely used and complicate policy. They have been rolled into the exemptions category instead.
- **Reduces excessive voting.**
  - Maintainers are encouraged to defer to other maintainers on things they are unsure about. Discussions on gameplay changes are held informally in organized spaces on Discord or the Forums. Maintainers are heavily discouraged from voting unless absolutely necessary.
- **Encourages more activity on the Docs repo by enabling higher throughput.**
  - Maintainers are reminded that they can directly push to the repo for most actions.
- **Shifts more work onto the Contributor.**
  - We have been doing a lot of work basically fixing up a contributor's pull requests. Pull requests often arrive with no justification or no high-level overview of the changes so it's really hard to review it because you have to figure out whatever they were thinking yourself.
  - Contributors either provide justification for their pull request or it gets closed.
  - Contributors are expected to read and understand our codebase conventions and guidelines to at least a 90% degree. If it is obvious that they have not read them, the PR is to be closed instantly.