### PR TITLE
Harpy Species Design Doc

### DIFF
--- a/src/en/space-station-14/character-species/proposals/harpy.md
+++ b/src/en/space-station-14/character-species/proposals/harpy.md
@@ -1,0 +1,41 @@
+# Harpy Species
+
+| Designers     | Implemented         | GitHub Links                                                                     |
+|---------------|---------------------|----------------------------------------------------------------------------------|
+| PAFFhassoocks | :x: Not Implemented | [Implementation PR](https://github.com/space-wizards/space-station-14) |
+
+## Overview
+
+The harpy species are nanotrasen approved birds
+
+## History of the species:
+
+harpies are on Goob, DeltaV, Frontier, Monolith, and prolly sum ss13 forks and corvax idk
+
+## Design
+
+harpies are BIRDS and they do bird things
+### Core Visual Elements
+
+harpies look like birds but not like vox
+
+### Species Features
+
+#### feature 1
+
+lightweight birds
+
+#### feature 2
+
+flapping they wing
+
+#### feature 3
+
+singing
+
+#### feature 4
+
+mimicking
+
+#### feature 5
+


### PR DESCRIPTION
This design document aims to get approval for the development of a PR adding the harpy as a species to wizden.