### PR TITLE
Collector xenobot

### DIFF
--- a/src/en/space-station-14/round-flow/antagonists/Xenoborgs.md
+++ b/src/en/space-station-14/round-flow/antagonists/Xenoborgs.md
@@ -76,7 +76,7 @@ It can't attack anything, can't repair other xenoborgs, and has very low hp. It'
 It can also help clean the mothership from all the giblets and assorted items left by people gibbed there.
 
 ### Mothership
-Is the shuttle the xenoborgs spawn in and is where the borging happens.
+The Mothership is the shuttle where the xenoborgs spawn and where borging happens.
 
 The borging is possible thanks to the mothership core, located in the center of the shuttle
 


### PR DESCRIPTION
Added documentation about a new type of "xenoborg"

the collector xenobot

# Why
- This would help ghost players to still be part of the xenoborg round even if they can't get converted anymore for some reason
- Despite being low cost and not needing brains they can't affect the combat at all
- Being able to get a steady supply of materials to the mothership would help xenoborgs stall less often due to low materials
- The mothership could start their attack on the station sooner given that they have speciallized bots getting materials and less need to salvage lots of materials in the begining of the round before being discovered by the crew
- They could also help clean the mothership of the tons of giblets of people

# Characteristics
- low cost
- no need for brain
- low hp
- not able to harm anything
- not able to repair xenoborgs
- able to float in space (similar to space carps, the stealth and the scout xenoborg)
- no radio
- no xenoborg transponder
- don't explode when the mothership is destroyed
- wouldn't drop anything that significantly helps the crew (like a pinpointer to the core)

## Modules
- basic xenobot module (almost like the basic xenoborg module but with no gps and one extra borg box)
- space movement module
- some form of tool module (experimental welder for sure, basic tools to deconstruct stuff)
- some module to help clean the mothership (still thinking what it would be)
