### PR TITLE
clarify review procedure

### DIFF
--- a/src/en/wizden-staff/maintainer/review-procedure.md
+++ b/src/en/wizden-staff/maintainer/review-procedure.md
@@ -5,7 +5,7 @@ This document outlines the Maintainer procedure for reviewing and merging PRs to
 
 Pull requests targeting the `staging` or `stable` branch are subject to the [Hotfix Procedure](hotfix-procedure.md).
 
-Any portion of this procedure may be waived and/or modified with written permission (_via Discord or GitHub_) from a Lead Maintainer, Project Manager or Wizard.
+Any portion of this procedure may be waived for single PRs with written permission (_via Discord or GitHub_) from a Lead Maintainer, Project Manager or Wizard.
 
 ```admonish note
 Note that these procedures are ultimately flexible; however, Maintainers who deviate from this policy are expected to provide concrete and valid reasoning when doing so.


### PR DESCRIPTION
Lead maintainers and PMs should not be handing out blanket waivers for ignoring the policy. I would already interprete the current text this way ("provide *concrete* and valid reasoning"), but I reformulated it a little to be more clear in that regard.

The policy exists for a reason to make sure the repository's code is up to standard and no bugs are sneaking in and handing out "you may ignore it whenever you want" passes is not healthy. If there is a problem with the policy we should change it instead.

@Simyon264 @VasilisThePikachu @juliangiebel 