### PR TITLE
Add feature / balance request triaging for Github Issues

### DIFF
--- a/src/en/wizden-staff/maintainer/triage-procedure.md
+++ b/src/en/wizden-staff/maintainer/triage-procedure.md
@@ -75,7 +75,7 @@ Non-Maintainer Triagers **must not** tag a PR as `S: Derelict`. This tag is to b
 
 #### Bug Reports
 
-Any Triager **may** close bug report Issues if they are no-longer relevant.
+Any triager **may** close bug report Issues if they are no longer relevant.
 
 When closing an issue, triage best practice involves adding a comment that contains one or more of the following:
 * a link to the PR that resolved it,
@@ -84,13 +84,13 @@ When closing an issue, triage best practice involves adding a comment that conta
 
 #### Feature / Balance Requests
 
-Github Issues is not meant to be an idea-guys forum. Any Triager **should** close feature / balance request Issues if they do not cite conceptual approval from a Maintainer. It is fine if the approval is just part of the Issue description, Maintainer doesn't need to comment on the Issue itself. If an Issue cites approval, Triagers **should** tag the Issue with the `S: Conceptual Approval` label.
+GitHub Issues is not intended to be an idea-guys forum. Any triager **should** close feature/balance request issues that do not cite conceptual approval from a maintainer. It is fine if the approval is included in the issue description; the maintainer doesn't need to comment on the issue itself. If an issue cites approval, triagers **should** tag the issue with the `S: Conceptual Approval` label.
 
-This applies to feature / balance requests created by Maintainers, which **must** have conceptual approval from another Maintainer. If a Maintainer-made request lacks approval, please for it before closing the Issue.
+This applies to feature/balance requests created by maintainers, which **must** have conceptual approval from another maintainer. If a maintainer-made request lacks approval, please request it before closing the issue.
 
 ### Never Closing PRs
 
-Non-Maintainer Triagers **must never** close Pull Requests. This is **always** a Maintainer responsibility.
+Non-maintainer triagers **must never** close pull requests. This is **always** a maintainer's responsibility.
 
 ## Other SS14 Github Label Categories
 
@@ -116,10 +116,10 @@ Some labels **should not** be used/removed by non-Maintainer Triagers, as they a
 | All Size tags                       | Applied automatically.*                                                                                                                             |
 | S: Approved                         | Only Maintainers can approve items. Applied automatically.                                                                                          |
 | S: Awaiting Changes                 | Applied automatically.                                                                                                                              |
-| S: Conceptual Approval              | Can only be applied by a Maintainer on PRs, following Review Procedure. Exception for [Issues](#feature--balance-requests).                         |
-| S: Undergoing Maintainer Discussion | Maintainer Discussions are at Maintainers' discretion.                                                                                              |
+| S: Conceptual Approval              | Can only be applied by a maintainer on PRs, following Review Procedure. Exception for [Issues](#feature--balance-requests).                         |
+| S: Undergoing Maintainer Discussion | Maintainer Discussions are at the maintainers' discretion.                                                                                              |
 | S: Art Approval                     | Can only be applied by an Art Lead following their approval. If the Art Lead has forgotten to apply it, Triagers may apply this label.              |
-| S: Concern                          | Only applied by a Maintainer with concern about a particular PR.                                                                                    |
+| S: Concern                          | Only applied by a maintainer with concern about a particular PR.                                                                                    |
 | S: DO NOT MERGE                     | Only applied by a Maintainer to PRs when that must be blocked from merging due to integration problems, extreme controversy, or other good reasons. |
 
 \* May still be applied in certain cases, if the automatic labelling is not working/not implemented.


### PR DESCRIPTION
This PR includes a change to the Triaging Procedure to give more freedom for Triagers to close feature and balance requests in Github Issues. 

In short; we have 3.7k issues and a fair number of them are feature or balance requests. Ideally Github Issues should be a place Contributors can easily pick up things to work on without worry, and having requests that will result in closed PRs or long lead times isn't respectful to either Contributors or Maintainers. 

It's better that these discussions happen on Discord or on the Forums, rather than Github Issues.