### PR TITLE
Clarify review procedure approval circumstances

### DIFF
--- a/src/en/wizden-staff/maintainer/review-procedure.md
+++ b/src/en/wizden-staff/maintainer/review-procedure.md
@@ -83,7 +83,7 @@ If the pull request does not line up with any category listed here, defer to two
     - These should usually come with a custom BenchmarkDotNet benchmark to prove that the PR has a meaningful effect on performance.
   - Player-facing changes large in impact.
     - Major additions like new antagonists, medical systems, atmospherics processing states, etc.
-    - Wide balancing revamps (ex. the rebalancing of an entire antagonists' store).
+    - Wide balancing revamps (ex. the rebalancing of an entire antagonist's store).
 
 #### Exceptions
 There are some exceptions to the one-approval or two-approval system. They are listed below.


### PR DESCRIPTION
Clarifies the amount of approvals needed for certain types of PRs. Before it was pretty unclear as to what counted as a one-approval or two-approval PR.

In general maintainers can merge a lot of small content under a single approval, though it's recommended to default to two approvals if unsure. The intention of the examples list is to build an idea of how many approvals certain PRs needs, not to enumerate every single PR type (which was a source of complication from the previous policy).