### PR TITLE
Update setting-up-ss14-watchdog.md

### DIFF
--- a/src/en/server-hosting/setting-up-ss14-watchdog.md
+++ b/src/en/server-hosting/setting-up-ss14-watchdog.md
@@ -44,7 +44,7 @@ git clone --recursive https://github.com/space-wizards/SS14.Watchdog
 cd SS14.Watchdog
 
 # Build the Watchdog.
-# The result is placed into: SS14.Watchdog/bin/Release/net9.0/linux-x64/publish
+# The result is placed into: SS14.Watchdog/bin/Release/net10.0/linux-x64/publish
 dotnet publish -c Release -r linux-x64 --no-self-contained
 ```
 


### PR DESCRIPTION
If we are on .net 10, as the download page linking to 10 implies, the release folder will have 10 as the name, not 9.





*Sorry if this PR is questionable, ive never made a pr. just wanted to suggest this small change.*