### PR TITLE
Adds self requested ban policy to banning policy

### DIFF
--- a/src/en/community/admin/wizards-den-banning-policy.md
+++ b/src/en/community/admin/wizards-den-banning-policy.md
@@ -348,6 +348,8 @@ If a ban appeal is handled by the banning admin and the ban is not fully removed
 ## Self Requested Bans
 A player may request a ban for any reason, for any duration of time. Such bans are not considered a ban for further administrative actions. Self-requested bans may only be requested through AHelp or admin messages on the forum. Requests through other channels should be met with instructions to submit them through the proper channels. At the player's request, the ban may be lifted before the requested time via a ban appeal. While admins are not required to honour ban requests, they should be honoured unless there are compelling reasons against placing a ban.
 
+
+
 ## Self Requested Ban appeal procedure
 Self-requested bans may only be prematurely removed through a successful appeal on the forums. Any other attempts (e.g., Discord) should be responded to by instructing the player to appeal on the forums.
 


### PR DESCRIPTION
This has previously been voted on by admins, I just only got around to pring it now.
Copying my reasoning behind the policy from the forums:
> This formalizes the processes used when interacting with self requested bans, and sets expectations for how they are treated for players. The vast majority of self-requested bans should be removed upon appeal, however in the very rare occasion that we feel its necessary to maintain a ban I have left leeway in the proposed policy to allow for that, although most investigation would be - check ban |> its self requested |> unban. This would also allow for most self requested bans to be handled by any admin, freeing up the appeals team.