### PR TITLE
Change pipe colors for waste and distro loops

### DIFF
--- a/src/en/space-station-14/mapping/guides/general-guide.md
+++ b/src/en/space-station-14/mapping/guides/general-guide.md
@@ -193,8 +193,8 @@ In order to create a life support system aboard your map you'll need to create a
 ### Standard Pipe Colors
 Prefer using standard pipe colors for your atmospherics layout so that players and other mappers can recognize them immediately.
 
-- Waste loop: #990000FF (red)
-- Distro loop: #0055CCFF (blue)
+- Waste loop: #990000FF (dull red)
+- Distro loop: #0055CCFF (subdued blue)
 - Air: #03FCD3FF (cyan)
 - Mix: #947507FF (brownish)
 


### PR DESCRIPTION
Unsure why this was changed to begin with. Most mappers use #990000FF and #0055CCFF for waste and distro loops respectively.