### PR TITLE
Added info about dependency version numbers into the build guide

### DIFF
--- a/src/en/meta/guide-to-editing-docs.md
+++ b/src/en/meta/guide-to-editing-docs.md
@@ -32,7 +32,7 @@ If you just want to make a basic edit of a page, simply follow these steps--you 
 
 ## Building
 
-If you want to locally build the docs, you need to install Rust, then install the project dependencies using `cargo`. It's recommended that you use `cargo install` or `cargo quickinstall`, as building can take a while. Because the project doesn't use the latest versions of these crates, you need to specify the correct version number, for example: `cargo install mdbook@0.4.36`. You can find the versions currently in use from [the deploy script](https://github.com/WizAntonioD/ss14-docs/blob/master/.github/workflows/deploy.yml) and the versions you have installed with `cargo install --list`.
+If you want to locally build the docs, you need to install Rust, then install the project dependencies using `cargo`. It's recommended that you use `cargo install` or `cargo quickinstall`, as building can take a while. Because the project doesn't use the latest versions of these crates, you need to specify the correct version number, for example: `cargo install mdbook@0.4.36`. You can find the versions currently in use from [the deploy script](https://github.com/space-wizards/docs/blob/master/.github/workflows/deploy.yml) and the versions you have installed with `cargo install --list`.
 
 From cargo, install:
 - `mdbook`


### PR DESCRIPTION
Added a link to the deploy script as the authoritative source for those version numbers, so they don't have to be separately maintained in the docs.