### PR TITLE
Rename job from test-summary to test-image-links

### DIFF
--- a/.github/workflows/test-image-links.yml
+++ b/.github/workflows/test-image-links.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 jobs:
-  test-summary:
+  test-image-links:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Renamed the workflow due to a copy paste oversight. It was showing up with the wrong name in the workflow list.

<img width="615" height="278" alt="grafik" src="https://github.com/user-attachments/assets/e6263680-ba99-40d6-b11d-cfd7619da786" />
