### PR TITLE
Update pull request guidelines to address PR size

### DIFF
--- a/src/en/general-development/codebase-info/pull-request-guidelines.md
+++ b/src/en/general-development/codebase-info/pull-request-guidelines.md
@@ -17,7 +17,7 @@ Your pull request may be reverted or closed for any reason.
 
 - Large new features and comprehensive reworks to existing large features (ie antags or anything that could be considered a subdepartment unto itself), should first be [proposed and accepted in abstract](../feature-proposals.md) before you start working on actually implementing it.
 
-- Don't make make giant PRs containing several thousand lines of code. Instead split them up into smaller parts, especially for major new features like antagonists or game modes. Implementing them one step at a time makes them much easier to review. On the other hand if your PR is too large it is very likely that it will not receive any reviews because reviewing it all at once is simply not feasible or would take multiple days of maintainer time. If want to start working on a larger project and are unsure where to start, best to talk to a maintainer beforehand.
+- Don't make make giant PRs containing several thousand lines of code. Instead split them up into smaller parts, especially for major new features like antagonists or game modes. Implementing them one step at a time makes them much easier to review. On the other hand if your PR is too large it is very likely that it will not receive any reviews because reviewing it all at once is simply not feasible or would take multiple days of maintainer time. If you want to start working on a larger project and are unsure where to start, best to talk to a maintainer beforehand.
 
 - Read the [Freezes and Restrictions issue](https://github.com/space-wizards/space-station-14/issues/8524) and make sure your PR does not interfere with anything or requires special requirements.
   

--- a/src/en/general-development/codebase-info/pull-request-guidelines.md
+++ b/src/en/general-development/codebase-info/pull-request-guidelines.md
@@ -17,6 +17,8 @@ Your pull request may be reverted or closed for any reason.
 
 - Large new features and comprehensive reworks to existing large features (ie antags or anything that could be considered a subdepartment unto itself), should first be [proposed and accepted in abstract](../feature-proposals.md) before you start working on actually implementing it.
 
+- Don't make make giant PRs containing several thousand lines of code. Instead split them up into smaller parts, especially for major new features like antagonists or game modes. Implementing them one step at a time makes them much easier to review. On the other hand if your PR is too large it is very likely that it will not receive any reviews because reviewing it all at once is simply not feasible or would take multiple days of maintainer time. If want to start working on a larger project and are unsure where to start, best to talk to a maintainer beforehand.
+
 - Read the [Freezes and Restrictions issue](https://github.com/space-wizards/space-station-14/issues/8524) and make sure your PR does not interfere with anything or requires special requirements.
   
 - If you are fixing a bug that is present on the live servers, or addressing an urgent balance issue on the live servers, consider if your change should be a hotfix.

--- a/src/en/general-development/codebase-info/pull-request-guidelines.md
+++ b/src/en/general-development/codebase-info/pull-request-guidelines.md
@@ -17,7 +17,7 @@ Your pull request may be reverted or closed for any reason.
 
 - Large new features and comprehensive reworks to existing large features (ie antags or anything that could be considered a subdepartment unto itself), should first be [proposed and accepted in abstract](../feature-proposals.md) before you start working on actually implementing it.
 
-- Don't make make giant PRs containing several thousand lines of code. Instead split them up into smaller parts, especially for major new features like antagonists or game modes. Implementing them one step at a time makes them much easier to review. On the other hand if your PR is too large it is very likely that it will not receive any reviews because reviewing it all at once is simply not feasible or would take multiple days of maintainer time. If you want to start working on a larger project and are unsure where to start, best to talk to a maintainer beforehand.
+- Don't make make giant PRs containing several thousand lines of code. Instead split them up into smaller parts, especially for major new features like antagonists or game modes. Implementing them one step at a time makes them much easier to review. On the other hand if your PR is too large it is very likely that it will not receive any reviews because reviewing it all at once is simply not feasible or would take multiple days of maintainer time. If you want to work on a larger project and are unsure where to start, best to talk to a maintainer beforehand.
 
 - Read the [Freezes and Restrictions issue](https://github.com/space-wizards/space-station-14/issues/8524) and make sure your PR does not interfere with anything or requires special requirements.
   


### PR DESCRIPTION
We sometimes get giant PRs that have thousands of lines of code, for example for new game modes and antags. As a result they often gather dust and are eventually closed because reviewing them all at once is simply unfeasible.

A few examples:
https://github.com/space-wizards/space-station-14/pull/42776
https://github.com/space-wizards/space-station-14/pull/30094
https://github.com/space-wizards/space-station-14/pull/24013
https://github.com/space-wizards/space-station-14/pull/40545

I added a small section in the PR guidelines warning contributors not to do this, so that they don't waste their time.