### PR TITLE
EVA Storage design doc

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -168,6 +168,8 @@ Space Station 14
 	- [PR Guidelines](en/space-station-14/mapping/guidelines.md)
 	
 	- [Dungeons](en/space-station-14/mapping/dungeons.md)
+
+	- [EVA Storage](en/space-station-14/mapping/eva-storage.md)
 	
 	- [Guides]()
 		- [General Guide](en/space-station-14/mapping/guides/general-guide.md)

--- a/src/en/space-station-14/mapping/eva-storage.md
+++ b/src/en/space-station-14/mapping/eva-storage.md
@@ -4,30 +4,29 @@ EVA Storage is a non-departmental room aboard the station containing various EVA
 
 EVA Storage isn't associated with any particular department, as many jobs aboard the station may need EVA gear for various tasks aboard the station. That being said, the room should be both Command and External access (i.e, anyone with either access is able to enter the room). This is because EVA gear can potentially be dangerous in the hands of bad actors; Command is trusted to dole out EVA equipment at least somewhat responsibly, and jobs with External access are already trusted with access to the same or similar equipment in the course of their regular duties. Command should additionally have the means to open the room to the entire crew, such as in the event of a stationwide atmospheric emergency. 
 
-# Room layout
+# Room specifications
 
 Since equipment in the room may be the target of theft by antagonists (as EVA gear provides spacing protection, the ability to move safely around the station's exterior, etc), the room should be slightly more secure than most rooms aboard the station (though not to the same extent as rooms like the Armory, Vault, or AI Core).
 - The room's airlocks should have a steel plate in them by default, similar to Command and Security airlocks.
 - The room's walls should be made of sturdy materials such as reinforced walls, reinforced glass with electric grilles, etc.
-- While it should be somewhat hard to _get into_ the room, additional security measures _inside_ of the room (such as portable flashers or turrets) are typically overkill.
+- While it should be somewhat hard to _get into_ the room, additional security measures _inside_ of the room (such as portable flashers or turrets) should typically be avoided.
 
 The room should contain a Command-locked button that toggles a way for all crew to access the room (typically by opening and bolting the room's airlocks). This allows Command to quickly open the room to crew without necessitating the use of a door remote or access configurator.
 
-EVA Storage should typically be located in close proximity to a "Command" area of the station for the sake of convenience (since, if a role doesn't have External access, they'll likely want to ask a member of Command to either let them in or to grab the relevant item(s) on their behalf). This may be near the bridge, though it could also be near another area of the station frequently occupied by a member of Command, such as the Head of Personnel's office.
-
-# Inventory
-
-In general, [quantities blah blah.]
-
-The following is the minimum standard for what equipment EVA Storage should contain. Other equipment, such as cell rechargers, toolboxes, etc, can also be included at the mapper's discretion.
-
-These items should always be accessible to anyone who's entered the room:
-- Standard EVA suits, typically stored in suit storage units
-- Oxygen and nitrogen canisters
+The room should additionally contain the following basic amenities:
+- Oxygen and nitrogen canisters (one of each)
 - A gas tank dispenser containing oxygen and nitrogen tanks
 - A holopad
 
-Additionally, the room should also have "more sensitive" items that require Command/External access to retrieve (such as via locked windoors, secure crates/lockers, or a secondary airlock). The additional layer of security is to prevent regular crew (i.e, crew with neither Command nor External access) from grabbing these items when the main doors have been publically opened.
+EVA Storage should typically be located in close proximity to a "Command" area of the station for the sake of convenience (since it's Command responsibility to open the room to the crew when necessary). This may be near the bridge, though it could also be near another area of the station frequently occupied by a member of Command, such as the Head of Personnel's office.
+
+# Inventory
+
+The following is the minimum standard for what equipment EVA Storage should contain. Other equipment, such as cell rechargers, toolboxes, etc, can also be included at the mapper's discretion.
+
+The room should contain enough EVA suits (including helmets and gas tanks) to fully outfit 10% of the station's expected population (e.g, 6 suits on a station designed for ~60 people). These should typically be kept in suit storage units (one unit per suit) for the sake of player readability (i.e, a player should be able to walk into a room with six suit storages, see that two of them are open and empty, and be able to easily infer that there's four suits left).
+
+Additionally, the room should also have "more advanced" equipment that directly require Command/External access to retrieve (such as via locked windoors, secure crates/lockers, or a secondary airlock). The additional layer of security is mainly to prevent regular crew (i.e, crew with neither Command nor External access) from grabbing these items when the main doors have been publically opened.
 - Magboots
 - Mini jetpacks
 

--- a/src/en/space-station-14/mapping/eva-storage.md
+++ b/src/en/space-station-14/mapping/eva-storage.md
@@ -1,0 +1,34 @@
+# Core concept
+
+EVA Storage is a non-departmental room aboard the station containing various EVA gear. The main purpose of the room is to contain a stockpile of "generic" EVA gear that the station can use as needed; maybe Science needs to deal with an anomaly on the station's exterior, maybe a Station Engineer got robbed of their hardsuit by an antagonist, or maybe the Mime just wants to build a bar on the exterior of the station. From a gameplay standpoint, the room also serves as a means for antagonists to acquire potentially useful equipment, via both social engineering and outright robbery.
+
+EVA Storage isn't associated with any particular department, as many jobs aboard the station may need EVA gear for various tasks aboard the station. That being said, the room should be both Command and External access (i.e, anyone with either access is able to enter the room). This is because EVA gear can potentially be dangerous in the hands of bad actors; Command is trusted to dole out EVA equipment at least somewhat responsibly, and jobs with External access are already trusted with access to the same or similar equipment in the course of their regular duties. Command should additionally have the means to open the room to the entire crew, such as in the event of a stationwide atmospheric emergency. 
+
+# Room layout
+
+Since equipment in the room may be the target of theft by antagonists (as EVA gear provides spacing protection, the ability to move safely around the station's exterior, etc), the room should be slightly more secure than most rooms aboard the station (though not to the same extent as rooms like the Armory, Vault, or AI Core).
+- The room's airlocks should have a steel plate in them by default, similar to Command and Security airlocks.
+- The room's walls should be made of sturdy materials such as reinforced walls, reinforced glass with electric grilles, etc.
+- While it should be somewhat hard to _get into_ the room, additional security measures _inside_ of the room (such as portable flashers or turrets) are typically overkill.
+
+The room should contain a Command-locked button that toggles a way for all crew to access the room (typically by opening and bolting the room's airlocks). This allows Command to quickly open the room to crew without necessitating the use of a door remote or access configurator.
+
+EVA Storage should typically be located in close proximity to a "Command" area of the station for the sake of convenience (since, if a role doesn't have External access, they'll likely want to ask a member of Command to either let them in or to grab the relevant item(s) on their behalf). This may be near the bridge, though it could also be near another area of the station frequently occupied by a member of Command, such as the Head of Personnel's office.
+
+# Inventory
+
+In general, [quantities blah blah.]
+
+The following is the minimum standard for what equipment EVA Storage should contain. Other equipment, such as cell rechargers, toolboxes, etc, can also be included at the mapper's discretion.
+
+These items should always be accessible to anyone who's entered the room:
+- Standard EVA suits, typically stored in suit storage units
+- Oxygen and nitrogen canisters
+- A gas tank dispenser containing oxygen and nitrogen tanks
+- A holopad
+
+Additionally, the room should also have "more sensitive" items that require Command/External access to retrieve (such as via locked windoors, secure crates/lockers, or a secondary airlock). The additional layer of security is to prevent regular crew (i.e, crew with neither Command nor External access) from grabbing these items when the main doors have been publically opened.
+- Magboots
+- Mini jetpacks
+
+EVA Storage should _not_ contain equipment specific to a particular department, since obtaining that kind of gear should require some form of interaction with the department itself, and EVA Storage isn't associated with any particular department. (e.g, an antagonist should need to break into Salvage if they specifically want to steal a salvage hardsuit.)

--- a/src/en/space-station-14/mapping/eva-storage.md
+++ b/src/en/space-station-14/mapping/eva-storage.md
@@ -18,7 +18,7 @@ The room should additionally contain the following basic amenities:
 - A gas tank dispenser containing oxygen and nitrogen tanks
 - A holopad
 
-EVA Storage should typically be located in close proximity to a "Command" area of the station for the sake of convenience (since it's Command responsibility to open the room to the crew when necessary). This may be near the bridge, though it could also be near another area of the station frequently occupied by a member of Command, such as the Head of Personnel's office.
+EVA Storage should typically be located in close proximity to a "Command" area of the station for the sake of convenience (since it's Command's responsibility to open the room to the crew when necessary). This may be near the bridge, though it could also be near another area of the station frequently occupied by a member of Command, such as the Head of Personnel's office.
 
 # Inventory
 


### PR DESCRIPTION
This doc details the purpose of the EVA Storage room, how it should generally be designed, and what items it should typically contain.

Consider this a companion to https://github.com/space-wizards/space-station-14/pull/41416. Despite EVA Storage being mapped on _every_ station, it's frustratingly inconsistent across stations. Some stations let anyone with Externals go into it, some are Command-only, some are Command _or_ External, some are _only the Head of Personnel specifically_. Accesses aside, there's also other weird consistencies, like Box having weird departmentally-locked closets containing single hardsuits and Oasis including full jetpacks _and_ grappling hooks. I think if we're going to map this room on every station we should have a consistent guideline for how it should be mapped.

This is my first time making a design doc so feedback is appreciated.